### PR TITLE
Implement generic index types

### DIFF
--- a/examples/complex_index.rs
+++ b/examples/complex_index.rs
@@ -138,7 +138,7 @@ fn main() {
 
     println!(
         "{} moves by king to get from {:?} to {:?}",
-        path.dist(&end).unwrap(),
+        path.dist(end).unwrap(),
         start,
         end
     );

--- a/examples/complex_index.rs
+++ b/examples/complex_index.rs
@@ -1,0 +1,145 @@
+#![feature(generic_associated_types)]
+
+use gryf::algo::{shortest_paths::unit, ShortestPaths};
+use gryf::prelude::*;
+use gryf::{marker::Direction, IndexType};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct ChessSquare(pub usize, pub usize);
+
+impl IndexType for ChessSquare {}
+
+struct Chessboard;
+
+impl GraphBase for Chessboard {
+    type VertexIndex = ChessSquare;
+    type EdgeIndex = ();
+}
+
+impl VerticesBaseWeak for Chessboard {
+    fn vertex_count_hint(&self) -> Option<usize> {
+        Some(8 * 8)
+    }
+
+    fn vertex_bound_hint(&self) -> Option<usize> {
+        Some(8 * 8)
+    }
+}
+
+impl EdgesBaseWeak<Undirected> for Chessboard {
+    fn edge_count_hint(&self) -> Option<usize> {
+        None
+    }
+
+    fn edge_bound_hint(&self) -> Option<usize> {
+        None
+    }
+
+    fn endpoints_weak(
+        &self,
+        _index: &Self::EdgeIndex,
+    ) -> Option<(Self::VertexIndex, Self::VertexIndex)> {
+        None
+    }
+
+    fn edge_index_weak(
+        &self,
+        _src: &Self::VertexIndex,
+        _dst: &Self::VertexIndex,
+    ) -> Option<Self::EdgeIndex> {
+        None
+    }
+}
+
+impl EdgesWeak<(), Undirected> for Chessboard {
+    fn edge_weak(&self, _index: &Self::EdgeIndex) -> Option<WeakRef<'_, ()>> {
+        Some(WeakRef::Owned(()))
+    }
+}
+
+impl Neighbors for Chessboard {
+    type NeighborRef<'a> = (ChessSquare, (), ChessSquare, Direction)
+    where
+        Self: 'a;
+
+    type NeighborsIter<'a> = ChessNeighborsIter
+    where
+        Self: 'a;
+
+    fn neighbors(&self, src: &Self::VertexIndex) -> Self::NeighborsIter<'_> {
+        ChessNeighborsIter {
+            src: *src,
+            index: 0,
+            dir: Outgoing,
+        }
+    }
+
+    fn neighbors_directed(
+        &self,
+        src: &Self::VertexIndex,
+        dir: Direction,
+    ) -> Self::NeighborsIter<'_> {
+        ChessNeighborsIter {
+            src: *src,
+            index: 0,
+            dir,
+        }
+    }
+}
+
+struct ChessNeighborsIter {
+    src: ChessSquare,
+    index: usize,
+    dir: Direction,
+}
+
+impl Iterator for ChessNeighborsIter {
+    type Item = (ChessSquare, (), ChessSquare, Direction);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // +---+---+---+
+            // | 0 | 1 | 2 |
+            // +---+---+---+
+            // | 3 | S | 4 |
+            // +---+---+---+
+            // | 5 | 6 | 7 |
+            // +---+---+---+
+            let ChessSquare(x, y) = self.src;
+            let (x, y) = match self.index {
+                0 => (x.wrapping_sub(1), y + 1),
+                1 => (x, y + 1),
+                2 => (x + 1, y + 1),
+                3 => (x.wrapping_sub(1), y),
+                4 => (x + 1, y),
+                5 => (x.wrapping_sub(1), y.wrapping_sub(1)),
+                6 => (x, y.wrapping_sub(1)),
+                7 => (x + 1, y.wrapping_sub(1)),
+                _ => return None,
+            };
+
+            self.index += 1;
+
+            if x >= 8 || y >= 8 {
+                // Position outside of board.
+                continue;
+            }
+
+            return Some((ChessSquare(x, y), (), self.src, self.dir));
+        }
+    }
+}
+
+fn main() {
+    let start = ChessSquare(0, 0);
+    let end = ChessSquare(4, 2);
+
+    let path = ShortestPaths::run_dijkstra(&Chessboard, start, Some(end), unit).unwrap();
+
+    println!(
+        "{} moves by king to get from {:?} to {:?}",
+        path.dist(&end).unwrap(),
+        start,
+        end
+    );
+}

--- a/examples/implicit_graph.rs
+++ b/examples/implicit_graph.rs
@@ -3,7 +3,7 @@
 use std::iter;
 
 use gryf::prelude::*;
-use gryf::{marker::Direction, visit::Dfs, Indexing, NumIndexType};
+use gryf::{marker::Direction, visit::Dfs, NumIndexType};
 
 // https://stackoverflow.com/questions/58870416/can-you-explain-implicit-graphsin-graph-theory-with-a-simple-example/58887179#58887179
 struct Collatz;
@@ -22,10 +22,7 @@ struct Neighbor {
     src: VertexIndex,
 }
 
-impl<Ix> NeighborRef<Ix> for Neighbor
-where
-    Ix: Indexing<VertexIndex = VertexIndex, EdgeIndex = EdgeIndex>,
-{
+impl NeighborRef<VertexIndex, EdgeIndex> for Neighbor {
     fn index(&self) -> WeakRef<'_, VertexIndex> {
         let n = self.src.to_bits();
         let c = if n % 2 == 0 { n / 2 } else { 3 * n + 1 };

--- a/examples/implicit_graph.rs
+++ b/examples/implicit_graph.rs
@@ -14,7 +14,7 @@ impl Collatz {
     }
 
     pub fn vertex_index(&self, n: u64) -> VertexIndex {
-        n.into()
+        VertexIndex::from_bits(n)
     }
 }
 
@@ -29,11 +29,11 @@ where
     fn index(&self) -> WeakRef<'_, VertexIndex> {
         let n = self.src.to_bits();
         let c = if n % 2 == 0 { n / 2 } else { 3 * n + 1 };
-        WeakRef::Owned(c.into())
+        WeakRef::Owned(VertexIndex::from_bits(c))
     }
 
     fn edge(&self) -> WeakRef<'_, EdgeIndex> {
-        WeakRef::Owned(self.src.to_bits().into())
+        WeakRef::Owned(EdgeIndex::from_bits(self.src.to_bits()))
     }
 
     fn src(&self) -> WeakRef<'_, VertexIndex> {

--- a/examples/shortest_path.rs
+++ b/examples/shortest_path.rs
@@ -14,21 +14,21 @@ fn main() {
     let florence = graph.add_vertex("Florence");
     let rome = graph.add_vertex("Rome");
 
-    graph.add_edge(&prague, &bratislava, 328u32);
-    graph.add_edge(&prague, &nuremberg, 293);
-    graph.add_edge(&bratislava, &vienna, 79);
-    graph.add_edge(&nuremberg, &munich, 170);
-    graph.add_edge(&vienna, &munich, 402);
-    graph.add_edge(&munich, &florence, 646);
-    graph.add_edge(&florence, &rome, 278);
+    graph.add_edge(prague, bratislava, 328u32);
+    graph.add_edge(prague, nuremberg, 293);
+    graph.add_edge(bratislava, vienna, 79);
+    graph.add_edge(nuremberg, munich, 170);
+    graph.add_edge(vienna, munich, 402);
+    graph.add_edge(munich, florence, 646);
+    graph.add_edge(florence, rome, 278);
 
     // As the edge weights are unsigned and there is a specific goal, Dijktra's
     // algorithm is applied. For signed edges, Bellman-Ford would be used.
     let shortest_paths = ShortestPaths::run(&graph, rome, Some(prague), identity).unwrap();
-    let distance = shortest_paths.dist(&prague).unwrap();
+    let distance = shortest_paths.dist(prague).unwrap();
     let path = shortest_paths
         .reconstruct(prague)
-        .map(|v| *graph.vertex(&v).unwrap())
+        .map(|v| *graph.vertex(v).unwrap())
         .collect::<Vec<_>>()
         .join(" - ");
 

--- a/examples/shortest_path.rs
+++ b/examples/shortest_path.rs
@@ -14,21 +14,21 @@ fn main() {
     let florence = graph.add_vertex("Florence");
     let rome = graph.add_vertex("Rome");
 
-    graph.add_edge(prague, bratislava, 328u32);
-    graph.add_edge(prague, nuremberg, 293);
-    graph.add_edge(bratislava, vienna, 79);
-    graph.add_edge(nuremberg, munich, 170);
-    graph.add_edge(vienna, munich, 402);
-    graph.add_edge(munich, florence, 646);
-    graph.add_edge(florence, rome, 278);
+    graph.add_edge(&prague, &bratislava, 328u32);
+    graph.add_edge(&prague, &nuremberg, 293);
+    graph.add_edge(&bratislava, &vienna, 79);
+    graph.add_edge(&nuremberg, &munich, 170);
+    graph.add_edge(&vienna, &munich, 402);
+    graph.add_edge(&munich, &florence, 646);
+    graph.add_edge(&florence, &rome, 278);
 
     // As the edge weights are unsigned and there is a specific goal, Dijktra's
     // algorithm is applied. For signed edges, Bellman-Ford would be used.
     let shortest_paths = ShortestPaths::run(&graph, rome, Some(prague), identity).unwrap();
-    let distance = shortest_paths.dist(prague).unwrap();
+    let distance = shortest_paths.dist(&prague).unwrap();
     let path = shortest_paths
         .reconstruct(prague)
-        .map(|v| *graph.vertex(v).unwrap())
+        .map(|v| *graph.vertex(&v).unwrap())
         .collect::<Vec<_>>()
         .join(" - ");
 

--- a/macros/src/util.rs
+++ b/macros/src/util.rs
@@ -104,7 +104,7 @@ pub fn augment_where_clause(
 
     let tokens = where_clause
         .map(|wc| wc.to_token_stream())
-        .unwrap_or_else(|| TokenStream2::new());
+        .unwrap_or_else(TokenStream2::new);
 
     let iter = AugmentWhereClause::new(bounds, tokens);
     iter.collect::<TokenStream2>()

--- a/src/algo/shortest_paths.rs
+++ b/src/algo/shortest_paths.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::cmp::{max, Reverse};
 use std::collections::{hash_map::Entry, BinaryHeap, HashSet};
 use std::hash::BuildHasherDefault;
@@ -130,8 +131,11 @@ where
         &self.start
     }
 
-    pub fn dist(&self, from: &G::VertexIndex) -> Option<&W> {
-        self.dist.get(from)
+    pub fn dist<VI>(&self, from: VI) -> Option<&W>
+    where
+        VI: Borrow<G::VertexIndex>,
+    {
+        self.dist.get(from.borrow())
     }
 
     pub fn reconstruct(&self, from: G::VertexIndex) -> PathReconstruction<'_, G> {

--- a/src/algo/shortest_paths.rs
+++ b/src/algo/shortest_paths.rs
@@ -1,6 +1,5 @@
 use std::cmp::{max, Reverse};
 use std::collections::{hash_map::Entry, BinaryHeap, HashSet};
-use std::fmt;
 use std::hash::BuildHasherDefault;
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -25,6 +24,7 @@ pub enum Error {
     EdgeNotAvailable,
 }
 
+#[derive(Debug)]
 pub struct ShortestPaths<W, G: GraphBase> {
     start: G::VertexIndex,
     // Using HashMaps because the algorithm supports early termination when
@@ -139,20 +139,6 @@ where
             curr: from,
             pred: &self.pred,
         }
-    }
-}
-
-impl<W, G: GraphBase> fmt::Debug for ShortestPaths<W, G>
-where
-    W: fmt::Debug,
-    G::VertexIndex: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ShortestPaths")
-            .field("start", &self.start)
-            .field("dist", &self.dist)
-            .field("pred", &self.pred)
-            .finish()
     }
 }
 

--- a/src/algo/shortest_paths.rs
+++ b/src/algo/shortest_paths.rs
@@ -282,7 +282,7 @@ where
     let mut dist = vec![W::inf(); vertex_map.len()];
     let mut pred = vec![Virtual::null(); vertex_map.len()];
 
-    dist[vertex_map.virt(start).unwrap().as_usize()] = W::zero();
+    dist[vertex_map.virt(start).unwrap().to_usize()] = W::zero();
 
     let mut terminated_early = false;
 
@@ -295,12 +295,12 @@ where
             let v = vertex_map.virt(*edge.dst()).unwrap();
 
             let edge_dist = edge_weight(edge.data());
-            let next_dist = dist[u.as_usize()].clone() + edge_dist;
+            let next_dist = dist[u.to_usize()].clone() + edge_dist;
 
             // Relax if better.
-            if next_dist < dist[v.as_usize()] {
-                dist[v.as_usize()] = next_dist;
-                pred[v.as_usize()] = u;
+            if next_dist < dist[v.to_usize()] {
+                dist[v.to_usize()] = next_dist;
+                pred[v.to_usize()] = u;
                 relaxed = true;
             }
         }
@@ -322,7 +322,7 @@ where
 
             let edge_dist = edge_weight(edge.data());
 
-            if dist[u.as_usize()].clone() + edge_dist < dist[v.as_usize()] {
+            if dist[u.to_usize()].clone() + edge_dist < dist[v.to_usize()] {
                 return Err(Error::NegativeCycle);
             }
         }
@@ -392,37 +392,33 @@ mod tests {
     #[test]
     fn dijkstra_basic() {
         let graph = create_basic_graph();
-        let shortest_paths =
-            ShortestPaths::run_dijkstra(&graph, 0usize.into(), None, identity).unwrap();
+        let shortest_paths = ShortestPaths::run_dijkstra(&graph, 0.into(), None, identity).unwrap();
 
-        assert_eq!(shortest_paths.dist(&4usize.into()), Some(&8));
+        assert_eq!(shortest_paths.dist(&4.into()), Some(&8));
         assert_eq!(
-            shortest_paths
-                .reconstruct(4usize.into())
-                .collect::<Vec<_>>(),
-            vec![3usize.into(), 1usize.into(), 0usize.into()]
+            shortest_paths.reconstruct(4.into()).collect::<Vec<_>>(),
+            vec![3.into(), 1.into(), 0.into()]
         );
 
-        assert_eq!(shortest_paths.dist(&2usize.into()), Some(&2));
+        assert_eq!(shortest_paths.dist(&2.into()), Some(&2));
     }
 
     #[test]
     fn dijkstra_early_termination() {
         let graph = create_basic_graph();
         let shortest_paths =
-            ShortestPaths::run_dijkstra(&graph, 0usize.into(), Some(4usize.into()), identity)
-                .unwrap();
+            ShortestPaths::run_dijkstra(&graph, 0.into(), Some(4.into()), identity).unwrap();
 
-        assert!(shortest_paths.dist(&5usize.into()).is_none());
+        assert!(shortest_paths.dist(&5.into()).is_none());
     }
 
     #[test]
     fn dijkstra_negative_edge() {
         let mut graph = create_basic_graph();
-        graph.replace_edge(&2usize.into(), -1);
+        graph.replace_edge(&2.into(), -1);
 
         let shortest_paths =
-            ShortestPaths::run_dijkstra(&graph, 0usize.into(), Some(4usize.into()), identity);
+            ShortestPaths::run_dijkstra(&graph, 0.into(), Some(4.into()), identity);
 
         assert_matches!(shortest_paths, Err(Error::NegativeWeight));
     }
@@ -430,37 +426,31 @@ mod tests {
     #[test]
     fn bellman_ford_basic() {
         let graph = create_basic_graph();
-        let shortest_paths =
-            ShortestPaths::run_bellman_ford(&graph, 0usize.into(), identity).unwrap();
+        let shortest_paths = ShortestPaths::run_bellman_ford(&graph, 0.into(), identity).unwrap();
 
-        assert_eq!(shortest_paths.dist(&4usize.into()), Some(&8));
+        assert_eq!(shortest_paths.dist(&4.into()), Some(&8));
         assert_eq!(
-            shortest_paths
-                .reconstruct(4usize.into())
-                .collect::<Vec<_>>(),
-            vec![3usize.into(), 1usize.into(), 0usize.into()]
+            shortest_paths.reconstruct(4.into()).collect::<Vec<_>>(),
+            vec![3.into(), 1.into(), 0.into()]
         );
 
-        assert_eq!(shortest_paths.dist(&2usize.into()), Some(&2));
+        assert_eq!(shortest_paths.dist(&2.into()), Some(&2));
     }
 
     #[test]
     fn bellman_ford_negative_edge() {
         let mut graph = create_basic_graph();
-        graph.replace_edge(&2usize.into(), -1);
+        graph.replace_edge(&2.into(), -1);
 
-        let shortest_paths =
-            ShortestPaths::run_bellman_ford(&graph, 0usize.into(), identity).unwrap();
+        let shortest_paths = ShortestPaths::run_bellman_ford(&graph, 0.into(), identity).unwrap();
 
-        assert_eq!(shortest_paths.dist(&4usize.into()), Some(&8));
+        assert_eq!(shortest_paths.dist(&4.into()), Some(&8));
         assert_eq!(
-            shortest_paths
-                .reconstruct(4usize.into())
-                .collect::<Vec<_>>(),
-            vec![3usize.into(), 1usize.into(), 0usize.into()]
+            shortest_paths.reconstruct(4.into()).collect::<Vec<_>>(),
+            vec![3.into(), 1.into(), 0.into()]
         );
 
-        assert_eq!(shortest_paths.dist(&2usize.into()), Some(&2));
+        assert_eq!(shortest_paths.dist(&2.into()), Some(&2));
     }
 
     #[test]
@@ -479,7 +469,7 @@ mod tests {
         graph.add_edge(&v2, &v1, -2);
         graph.add_edge(&v2, &v4, 3);
 
-        let shortest_paths = ShortestPaths::run_bellman_ford(&graph, 0usize.into(), identity);
+        let shortest_paths = ShortestPaths::run_bellman_ford(&graph, 0.into(), identity);
 
         assert_matches!(shortest_paths, Err(Error::NegativeCycle));
     }

--- a/src/algo/toposort.rs
+++ b/src/algo/toposort.rs
@@ -186,7 +186,7 @@ where
     graph: &'a G,
     map: CompactIndexMap<G::VertexIndex>,
     in_deg: Vec<usize>,
-    // Does not need to be LIFO as the order of reported vertices with in degree
+    // Does not need to be FIFO as the order of reported vertices with in degree
     // 0 does not matter.
     queue: Vec<G::VertexIndex>,
     visited: usize,

--- a/src/algo/toposort.rs
+++ b/src/algo/toposort.rs
@@ -254,8 +254,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::fmt;
-
     use super::*;
 
     use crate::{
@@ -271,7 +269,7 @@ mod tests {
             + EdgesBase<Directed>
             + VerticesBaseWeak
             + EdgesBaseWeak<Directed>,
-        G::VertexIndex: NumIndexType + fmt::Debug,
+        G::VertexIndex: NumIndexType,
     {
         let sorted = toposort.collect::<Result<Vec<_>, _>>();
 

--- a/src/algo/toposort.rs
+++ b/src/algo/toposort.rs
@@ -233,7 +233,7 @@ where
             self.visited += 1;
 
             for n in self.graph.neighbors_directed(&vertex, Direction::Outgoing) {
-                let i = self.map.virt(*n.index()).unwrap().as_usize();
+                let i = self.map.virt(*n.index()).unwrap().to_usize();
                 let deg = &mut self.in_deg[i];
                 *deg -= 1;
 

--- a/src/algo/toposort.rs
+++ b/src/algo/toposort.rs
@@ -1,11 +1,14 @@
+use std::hash::BuildHasherDefault;
+
+use rustc_hash::FxHashSet;
+
 use crate::{
-    index::VertexIndex,
-    infra::{CompactIndexMap, TypedBitSet, VisitSet},
+    index::{NumIndexType, UseVertexIndex},
+    infra::{CompactIndexMap, VisitSet},
     marker::{Directed, Direction},
     operator::Transpose,
     traits::*,
     visit::{self, raw::*, VisitAll, Visitor},
-    IndexType,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,7 +34,10 @@ impl<'a, G> TopoSort<'a, G>
 where
     G: Neighbors + VerticesBase + EdgesBase<Directed>,
 {
-    pub fn run_algo(graph: &'a G, algo: Option<Algo>) -> Self {
+    pub fn run_algo(graph: &'a G, algo: Option<Algo>) -> Self
+    where
+        G::VertexIndex: NumIndexType,
+    {
         match algo {
             Some(Algo::Dfs) | None => Self {
                 inner: TopoSortInner::Dfs(Self::run_dfs(graph).into_iter(graph)),
@@ -42,7 +48,10 @@ where
         }
     }
 
-    pub fn run(graph: &'a G) -> Self {
+    pub fn run(graph: &'a G) -> Self
+    where
+        G::VertexIndex: NumIndexType,
+    {
         Self::run_algo(graph, None)
     }
 
@@ -50,7 +59,10 @@ where
         DfsVisit::new(graph)
     }
 
-    pub fn run_kahn(graph: &'a G) -> KahnIter<'a, G> {
+    pub fn run_kahn(graph: &'a G) -> KahnIter<'a, G>
+    where
+        G::VertexIndex: NumIndexType,
+    {
         KahnIter::new(graph)
     }
 }
@@ -58,8 +70,9 @@ where
 impl<'a, G> Iterator for TopoSort<'a, G>
 where
     G: Neighbors + VerticesBase + EdgesBase<Directed>,
+    G::VertexIndex: NumIndexType,
 {
-    type Item = Result<VertexIndex, Error>;
+    type Item = Result<G::VertexIndex, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
@@ -77,8 +90,9 @@ where
 impl<'a, G> Iterator for TopoSortInner<'a, G>
 where
     G: Neighbors + VerticesBase + EdgesBase<Directed>,
+    G::VertexIndex: NumIndexType,
 {
-    type Item = Result<VertexIndex, Error>;
+    type Item = Result<G::VertexIndex, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -92,9 +106,9 @@ pub struct DfsVisit<'a, G>
 where
     G: VerticesBase + 'a,
 {
-    raw: RawVisit<RawDfsExtra>,
-    multi: RawVisitMulti<RawDfsExtra, VisitAll<'a, G>>,
-    closed: TypedBitSet<VertexIndex>,
+    raw: RawVisit<G, UseVertexIndex, RawDfsExtra>,
+    multi: RawVisitMulti<G, UseVertexIndex, RawDfsExtra, VisitAll<'a, G>>,
+    closed: FxHashSet<G::VertexIndex>,
 }
 
 impl<'a, G> DfsVisit<'a, G>
@@ -105,7 +119,10 @@ where
         Self {
             raw: RawVisit::new(Some(graph.vertex_count())),
             multi: RawVisitMulti::new(VisitAll::new(graph)),
-            closed: TypedBitSet::with_capacity(graph.vertex_count()),
+            closed: FxHashSet::with_capacity_and_hasher(
+                graph.vertex_count(),
+                BuildHasherDefault::default(),
+            ),
         }
     }
 }
@@ -114,7 +131,7 @@ impl<'a, G> Visitor<G> for DfsVisit<'a, G>
 where
     G: Neighbors + VerticesBase + EdgesBase<Directed>,
 {
-    type Item = Result<VertexIndex, Error>;
+    type Item = Result<G::VertexIndex, Error>;
 
     fn next(&mut self, graph: &G) -> Option<Self::Item> {
         // The implementation differs from classic DFS algorithm for topological
@@ -135,7 +152,7 @@ where
                 &mut self.raw,
                 |raw| {
                     raw.next(graph, |_, raw_event| match raw_event {
-                        RawEvent::Skip { vertex, .. } if !self.closed.is_visited(vertex) => {
+                        RawEvent::Skip { vertex, .. } if !self.closed.is_visited(&vertex) => {
                             // Vertex not added to the stack, but also
                             // has not been closed. That means that we
                             // encountered a back edge.
@@ -147,7 +164,7 @@ where
                         _ => true,
                     })
                 },
-                |vertex| graph.contains_vertex(*vertex),
+                |vertex| graph.contains_vertex(vertex),
             )?;
 
             if cycle {
@@ -155,26 +172,30 @@ where
             }
 
             if let RawDfsExtraEvent::Close(vertex) = raw_extra_event {
-                self.closed.visit(vertex);
+                self.closed.visit(vertex.clone());
                 return Some(Ok(vertex));
             }
         }
     }
 }
 
-pub struct KahnIter<'a, G> {
+pub struct KahnIter<'a, G>
+where
+    G: GraphBase,
+{
     graph: &'a G,
-    map: CompactIndexMap<VertexIndex>,
+    map: CompactIndexMap<G::VertexIndex>,
     in_deg: Vec<usize>,
     // Does not need to be LIFO as the order of reported vertices with in degree
     // 0 does not matter.
-    queue: Vec<VertexIndex>,
+    queue: Vec<G::VertexIndex>,
     visited: usize,
 }
 
 impl<'a, G> KahnIter<'a, G>
 where
     G: Neighbors + VerticesBase + 'a,
+    G::VertexIndex: NumIndexType,
 {
     fn new(graph: &'a G) -> Self {
         let map = graph.vertex_index_map();
@@ -182,7 +203,7 @@ where
         let mut queue = Vec::new();
 
         for v in graph.vertex_indices() {
-            let deg = graph.degree_directed(v, Direction::Incoming);
+            let deg = graph.degree_directed(&v, Direction::Incoming);
             in_deg.push(deg);
 
             if deg == 0 {
@@ -203,20 +224,21 @@ where
 impl<'a, G> Iterator for KahnIter<'a, G>
 where
     G: Neighbors,
+    G::VertexIndex: NumIndexType,
 {
-    type Item = Result<VertexIndex, Error>;
+    type Item = Result<G::VertexIndex, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(vertex) = self.queue.pop() {
             self.visited += 1;
 
-            for n in self.graph.neighbors_directed(vertex, Direction::Outgoing) {
-                let i = self.map.virt(n.index()).unwrap().to_usize();
+            for n in self.graph.neighbors_directed(&vertex, Direction::Outgoing) {
+                let i = self.map.virt(*n.index()).unwrap().as_usize();
                 let deg = &mut self.in_deg[i];
                 *deg -= 1;
 
                 if *deg == 0 {
-                    self.queue.push(n.index());
+                    self.queue.push(*n.index());
                 }
             }
 
@@ -232,9 +254,12 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::fmt;
+
     use super::*;
 
     use crate::{
+        index::DefaultIndexing,
         storage::AdjList,
         visit::{DfsEvent, DfsEvents},
     };
@@ -246,6 +271,7 @@ mod tests {
             + EdgesBase<Directed>
             + VerticesBaseWeak
             + EdgesBaseWeak<Directed>,
+        G::VertexIndex: NumIndexType + fmt::Debug,
     {
         let sorted = toposort.collect::<Result<Vec<_>, _>>();
 
@@ -260,19 +286,19 @@ mod tests {
 
         match (sorted, cycle) {
             (Ok(sorted), None) => {
-                for (src, dst) in graph.edge_indices().map(|e| graph.endpoints(e).unwrap()) {
+                for (src, dst) in graph.edge_indices().map(|e| graph.endpoints(&e).unwrap()) {
                     let i = sorted
                         .iter()
                         .copied()
                         .enumerate()
-                        .find_map(|(k, v)| (v == src).then(|| Some(k)))
+                        .find_map(|(k, v)| (v == src).then_some(Some(k)))
                         .unwrap_or_else(|| panic!("algorithm omitted vertex {:?}", src));
 
                     let j = sorted
                         .iter()
                         .copied()
                         .enumerate()
-                        .find_map(|(k, v)| (v == dst).then(|| Some(k)))
+                        .find_map(|(k, v)| (v == dst).then_some(Some(k)))
                         .unwrap_or_else(|| panic!("algorithm omitted vertex {:?}", dst));
 
                     assert!(
@@ -289,7 +315,7 @@ mod tests {
         }
     }
 
-    fn create_basic_graph() -> AdjList<(), (), Directed> {
+    fn create_basic_graph() -> AdjList<(), (), Directed, DefaultIndexing> {
         let mut graph = AdjList::default();
 
         let v0 = graph.add_vertex(());
@@ -299,17 +325,17 @@ mod tests {
         let v4 = graph.add_vertex(());
         let v5 = graph.add_vertex(());
 
-        graph.add_edge(v5, v2, ());
-        graph.add_edge(v5, v0, ());
-        graph.add_edge(v4, v0, ());
-        graph.add_edge(v4, v1, ());
-        graph.add_edge(v2, v3, ());
-        graph.add_edge(v3, v1, ());
+        graph.add_edge(&v5, &v2, ());
+        graph.add_edge(&v5, &v0, ());
+        graph.add_edge(&v4, &v0, ());
+        graph.add_edge(&v4, &v1, ());
+        graph.add_edge(&v2, &v3, ());
+        graph.add_edge(&v3, &v1, ());
 
         graph
     }
 
-    fn create_cyclic_graph() -> AdjList<(), (), Directed> {
+    fn create_cyclic_graph() -> AdjList<(), (), Directed, DefaultIndexing> {
         let mut graph = AdjList::default();
 
         let v0 = graph.add_vertex(());
@@ -319,19 +345,19 @@ mod tests {
         let v4 = graph.add_vertex(());
         let v5 = graph.add_vertex(());
 
-        graph.add_edge(v5, v2, ());
-        graph.add_edge(v5, v0, ());
-        graph.add_edge(v4, v0, ());
-        graph.add_edge(v4, v1, ());
-        graph.add_edge(v2, v3, ());
-        graph.add_edge(v3, v1, ());
+        graph.add_edge(&v5, &v2, ());
+        graph.add_edge(&v5, &v0, ());
+        graph.add_edge(&v4, &v0, ());
+        graph.add_edge(&v4, &v1, ());
+        graph.add_edge(&v2, &v3, ());
+        graph.add_edge(&v3, &v1, ());
 
-        graph.add_edge(v1, v5, ());
+        graph.add_edge(&v1, &v5, ());
 
         graph
     }
 
-    fn create_disconnected_graph() -> AdjList<(), (), Directed> {
+    fn create_disconnected_graph() -> AdjList<(), (), Directed, DefaultIndexing> {
         let mut graph = AdjList::default();
 
         let v0 = graph.add_vertex(());
@@ -341,22 +367,22 @@ mod tests {
         let v4 = graph.add_vertex(());
         let v5 = graph.add_vertex(());
 
-        graph.add_edge(v5, v2, ());
-        graph.add_edge(v5, v0, ());
-        graph.add_edge(v4, v0, ());
-        graph.add_edge(v4, v1, ());
-        graph.add_edge(v2, v3, ());
-        graph.add_edge(v3, v1, ());
+        graph.add_edge(&v5, &v2, ());
+        graph.add_edge(&v5, &v0, ());
+        graph.add_edge(&v4, &v0, ());
+        graph.add_edge(&v4, &v1, ());
+        graph.add_edge(&v2, &v3, ());
+        graph.add_edge(&v3, &v1, ());
 
         let v6 = graph.add_vertex(());
         let v7 = graph.add_vertex(());
         let v8 = graph.add_vertex(());
         let v9 = graph.add_vertex(());
 
-        graph.add_edge(v7, v6, ());
-        graph.add_edge(v7, v8, ());
-        graph.add_edge(v6, v9, ());
-        graph.add_edge(v8, v9, ());
+        graph.add_edge(&v7, &v6, ());
+        graph.add_edge(&v7, &v8, ());
+        graph.add_edge(&v6, &v9, ());
+        graph.add_edge(&v8, &v9, ());
 
         graph
     }

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -2,17 +2,18 @@ use std::{fmt, marker::PhantomData};
 
 use arbitrary::{Arbitrary, Unstructured};
 
-use crate::index::{EdgeIndex, VertexIndex};
+use crate::index::NumIndexType;
 use crate::infra::CompactIndexMap;
 use crate::marker::{Direction, EdgeType};
 use crate::testing::{Applier, ApplyMutOps, MutOp};
 use crate::traits::*;
 use crate::{
-    Edges, EdgesBase, EdgesBaseWeak, EdgesMut, EdgesWeak, Guarantee, Neighbors, Vertices,
-    VerticesBase, VerticesBaseWeak, VerticesMut, VerticesWeak,
+    Edges, EdgesBase, EdgesBaseWeak, EdgesMut, EdgesWeak, GraphBase, Guarantee, Neighbors,
+    Vertices, VerticesBase, VerticesBaseWeak, VerticesMut, VerticesWeak,
 };
 
 #[derive(
+    GraphBase,
     VerticesBase,
     Vertices,
     VerticesMut,
@@ -46,6 +47,7 @@ where
     V: Arbitrary<'a>,
     E: Arbitrary<'a>,
     G: Default + VerticesMut<V> + EdgesMut<E, Ty>,
+    G::VertexIndex: NumIndexType,
 {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut graph = G::default();
@@ -101,6 +103,7 @@ impl<V, E, Ty: EdgeType, G> ArbitraryGraph<V, E, Ty, G> {
 mod tests {
     use super::*;
 
+    use crate::index::DefaultIndexing;
     use crate::marker::Undirected;
     use crate::storage::AdjList;
 
@@ -108,6 +111,6 @@ mod tests {
     fn is_arbitrary() {
         fn assert_arbitrary<'a, T: Arbitrary<'a>>() {}
 
-        assert_arbitrary::<ArbitraryGraph<(), (), Undirected, AdjList<_, _, _>>>();
+        assert_arbitrary::<ArbitraryGraph<(), (), Undirected, AdjList<_, _, _, DefaultIndexing>>>();
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::io::{self, Write};
 use std::marker::PhantomData;
@@ -49,6 +50,8 @@ where
             out.write_all(b"graph ")?;
         }
 
+        let mut indexer = Indexer::new();
+
         out.write_all(self.name.as_bytes())?;
         out.write_all(b" {\n")?;
 
@@ -56,7 +59,7 @@ where
             out.write_all(
                 format!(
                     "    v{} [label={:?}];\n",
-                    vertex.index().to_usize(),
+                    indexer.get(vertex.index()),
                     (self.get_vertex_label)(vertex.data())
                 )
                 .as_bytes(),
@@ -68,9 +71,9 @@ where
             out.write_all(
                 format!(
                     "    v{} {} v{} [label={:?}];\n",
-                    edge.src().to_usize(),
+                    indexer.get(edge.src()),
                     line,
-                    edge.dst().to_usize(),
+                    indexer.get(edge.dst()),
                     (self.get_edge_label)(edge.data())
                 )
                 .as_bytes(),
@@ -80,5 +83,19 @@ where
         out.write_all(b"}\n")?;
 
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct Indexer<Idx>(HashMap<Idx, usize>);
+
+impl<Idx: IndexType> Indexer<Idx> {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn get(&mut self, idx: &Idx) -> usize {
+        let new_idx = self.0.len();
+        *self.0.entry(idx.clone()).or_insert(new_idx)
     }
 }

--- a/src/graph/generic.rs
+++ b/src/graph/generic.rs
@@ -1,18 +1,19 @@
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
-use crate::index::{EdgeIndex, VertexIndex};
+use crate::index::{DefaultIndexing, NumIndexType};
 use crate::infra::CompactIndexMap;
 use crate::marker::{Directed, Direction, EdgeType, Undirected};
 use crate::storage::{AdjList, Frozen, Stable};
 use crate::traits::*;
 use crate::{
-    Edges, EdgesBase, EdgesBaseWeak, EdgesMut, EdgesWeak, Guarantee, MultiEdges, Neighbors,
-    Vertices, VerticesBase, VerticesBaseWeak, VerticesMut, VerticesWeak,
+    Edges, EdgesBase, EdgesBaseWeak, EdgesMut, EdgesWeak, GraphBase, Guarantee, MultiEdges,
+    Neighbors, Vertices, VerticesBase, VerticesBaseWeak, VerticesMut, VerticesWeak,
 };
 
 #[derive(
     Debug,
+    GraphBase,
     VerticesBase,
     Vertices,
     VerticesMut,
@@ -33,7 +34,7 @@ pub struct Graph<V, E, Ty: EdgeType, G> {
     ty: PhantomData<(V, E, Ty)>,
 }
 
-impl<V, E, Ty: EdgeType> Graph<V, E, Ty, AdjList<V, E, Ty>> {
+impl<V, E, Ty: EdgeType> Graph<V, E, Ty, AdjList<V, E, Ty, DefaultIndexing>> {
     pub fn new() -> Self {
         Self::with_storage(AdjList::new())
     }
@@ -43,13 +44,13 @@ impl<V, E, Ty: EdgeType> Graph<V, E, Ty, AdjList<V, E, Ty>> {
     }
 }
 
-impl<V, E> Graph<V, E, Undirected, AdjList<V, E, Undirected>> {
+impl<V, E> Graph<V, E, Undirected, AdjList<V, E, Undirected, DefaultIndexing>> {
     pub fn new_undirected() -> Self {
         Self::new()
     }
 }
 
-impl<V, E> Graph<V, E, Directed, AdjList<V, E, Directed>> {
+impl<V, E> Graph<V, E, Directed, AdjList<V, E, Directed, DefaultIndexing>> {
     pub fn new_directed() -> Self {
         Self::new()
     }
@@ -80,7 +81,7 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
 
     pub fn extend_with_edges<T, I>(&mut self, iter: I)
     where
-        T: IntoEdge<E, Ty>,
+        T: IntoEdge<G, E, Ty>,
         I: IntoIterator<Item = T>,
         V: Default,
         G: ExtendWithEdges<T, V, E, Ty>,
@@ -90,7 +91,7 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
 
     pub fn from_edges<T, I>(iter: I) -> Self
     where
-        T: IntoEdge<E, Ty>,
+        T: IntoEdge<G, E, Ty>,
         I: IntoIterator<Item = T>,
         V: Default,
         G: ExtendWithEdges<T, V, E, Ty>,
@@ -135,42 +136,42 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.vertex_indices()
     }
 
-    pub fn vertex(&self, index: VertexIndex) -> Option<&V>
+    pub fn vertex(&self, index: &G::VertexIndex) -> Option<&V>
     where
         G: Vertices<V>,
     {
         self.graph.vertex(index)
     }
 
-    pub fn vertices(&self) -> G::VerticesIter<'_, V>
+    pub fn vertices(&self) -> G::VerticesIter<'_>
     where
         G: Vertices<V>,
     {
         self.graph.vertices()
     }
 
-    pub fn vertex_mut(&mut self, index: VertexIndex) -> Option<&mut V>
+    pub fn vertex_mut(&mut self, index: &G::VertexIndex) -> Option<&mut V>
     where
         G: VerticesMut<V>,
     {
         self.graph.vertex_mut(index)
     }
 
-    pub fn add_vertex(&mut self, vertex: V) -> VertexIndex
+    pub fn add_vertex(&mut self, vertex: V) -> G::VertexIndex
     where
         G: VerticesMut<V>,
     {
         self.graph.add_vertex(vertex)
     }
 
-    pub fn remove_vertex(&mut self, index: VertexIndex) -> Option<V>
+    pub fn remove_vertex(&mut self, index: &G::VertexIndex) -> Option<V>
     where
         G: VerticesMut<V>,
     {
         self.graph.remove_vertex(index)
     }
 
-    pub fn replace_vertex(&mut self, index: VertexIndex, vertex: V) -> V
+    pub fn replace_vertex(&mut self, index: &G::VertexIndex, vertex: V) -> V
     where
         G: VerticesMut<V>,
     {
@@ -198,14 +199,14 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.edge_bound()
     }
 
-    pub fn endpoints(&self, index: EdgeIndex) -> Option<(VertexIndex, VertexIndex)>
+    pub fn endpoints(&self, index: &G::EdgeIndex) -> Option<(G::VertexIndex, G::VertexIndex)>
     where
         G: EdgesBase<Ty>,
     {
         self.graph.endpoints(index)
     }
 
-    pub fn edge_index(&self, src: VertexIndex, dst: VertexIndex) -> Option<EdgeIndex>
+    pub fn edge_index(&self, src: &G::VertexIndex, dst: &G::VertexIndex) -> Option<G::EdgeIndex>
     where
         G: EdgesBase<Ty>,
     {
@@ -219,7 +220,7 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.edge_indices()
     }
 
-    pub fn contains_edge(&self, index: EdgeIndex) -> bool
+    pub fn contains_edge(&self, index: &G::EdgeIndex) -> bool
     where
         G: EdgesBase<Ty>,
     {
@@ -233,42 +234,42 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.is_directed()
     }
 
-    pub fn edge(&self, index: EdgeIndex) -> Option<&E>
+    pub fn edge(&self, index: &G::EdgeIndex) -> Option<&E>
     where
         G: Edges<E, Ty>,
     {
         self.graph.edge(index)
     }
 
-    pub fn edges(&self) -> G::EdgesIter<'_, E>
+    pub fn edges(&self) -> G::EdgesIter<'_>
     where
         G: Edges<E, Ty>,
     {
         self.graph.edges()
     }
 
-    pub fn edge_mut(&mut self, index: EdgeIndex) -> Option<&mut E>
+    pub fn edge_mut(&mut self, index: &G::EdgeIndex) -> Option<&mut E>
     where
         G: EdgesMut<E, Ty>,
     {
         self.graph.edge_mut(index)
     }
 
-    pub fn add_edge(&mut self, src: VertexIndex, dst: VertexIndex, edge: E) -> EdgeIndex
+    pub fn add_edge(&mut self, src: &G::VertexIndex, dst: &G::VertexIndex, edge: E) -> G::EdgeIndex
     where
         G: EdgesMut<E, Ty>,
     {
         self.graph.add_edge(src, dst, edge)
     }
 
-    pub fn remove_edge(&mut self, index: EdgeIndex) -> Option<E>
+    pub fn remove_edge(&mut self, index: &G::EdgeIndex) -> Option<E>
     where
         G: EdgesMut<E, Ty>,
     {
         self.graph.remove_edge(index)
     }
 
-    pub fn replace_edge(&mut self, index: EdgeIndex, edge: E) -> E
+    pub fn replace_edge(&mut self, index: &G::EdgeIndex, edge: E) -> E
     where
         G: EdgesMut<E, Ty>,
     {
@@ -284,8 +285,8 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
 
     pub fn multi_edge_index(
         &self,
-        src: VertexIndex,
-        dst: VertexIndex,
+        src: &G::VertexIndex,
+        dst: &G::VertexIndex,
     ) -> G::MultiEdgeIndicesIter<'_>
     where
         G: MultiEdges<E, Ty>,
@@ -293,35 +294,38 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.multi_edge_index(src, dst)
     }
 
-    pub fn neighbors(&self, src: VertexIndex) -> G::NeighborsIter<'_>
+    pub fn neighbors(&self, src: &G::VertexIndex) -> G::NeighborsIter<'_>
     where
         G: Neighbors,
     {
         self.graph.neighbors(src)
     }
 
-    pub fn neighbors_directed(&self, src: VertexIndex, dir: Direction) -> G::NeighborsIter<'_>
+    pub fn neighbors_directed(&self, src: &G::VertexIndex, dir: Direction) -> G::NeighborsIter<'_>
     where
         G: Neighbors,
     {
         self.graph.neighbors_directed(src, dir)
     }
 
-    pub fn degree(&self, src: VertexIndex) -> usize
+    pub fn degree(&self, src: &G::VertexIndex) -> usize
     where
         G: Neighbors,
     {
         self.graph.degree(src)
     }
 
-    pub fn degree_directed(&self, src: VertexIndex, dir: Direction) -> usize
+    pub fn degree_directed(&self, src: &G::VertexIndex, dir: Direction) -> usize
     where
         G: Neighbors,
     {
         self.graph.degree_directed(src, dir)
     }
 
-    pub fn stabilize(self) -> Graph<V, E, Ty, Stable<G>> {
+    pub fn stabilize(self) -> Graph<V, E, Ty, Stable<G>>
+    where
+        G: GraphBase,
+    {
         Graph::with_storage(Stable::new(self.graph))
     }
 

--- a/src/graph/generic.rs
+++ b/src/graph/generic.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
@@ -136,11 +137,12 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.vertex_indices()
     }
 
-    pub fn vertex(&self, index: &G::VertexIndex) -> Option<&V>
+    pub fn vertex<VI>(&self, index: VI) -> Option<&V>
     where
         G: Vertices<V>,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.vertex(index)
+        self.graph.vertex(index.borrow())
     }
 
     pub fn vertices(&self) -> G::VerticesIter<'_>
@@ -150,11 +152,12 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.vertices()
     }
 
-    pub fn vertex_mut(&mut self, index: &G::VertexIndex) -> Option<&mut V>
+    pub fn vertex_mut<VI>(&mut self, index: VI) -> Option<&mut V>
     where
         G: VerticesMut<V>,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.vertex_mut(index)
+        self.graph.vertex_mut(index.borrow())
     }
 
     pub fn add_vertex(&mut self, vertex: V) -> G::VertexIndex
@@ -164,18 +167,20 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.add_vertex(vertex)
     }
 
-    pub fn remove_vertex(&mut self, index: &G::VertexIndex) -> Option<V>
+    pub fn remove_vertex<VI>(&mut self, index: VI) -> Option<V>
     where
         G: VerticesMut<V>,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.remove_vertex(index)
+        self.graph.remove_vertex(index.borrow())
     }
 
-    pub fn replace_vertex(&mut self, index: &G::VertexIndex, vertex: V) -> V
+    pub fn replace_vertex<VI>(&mut self, index: VI, vertex: V) -> V
     where
         G: VerticesMut<V>,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.replace_vertex(index, vertex)
+        self.graph.replace_vertex(index.borrow(), vertex)
     }
 
     pub fn clear(&mut self)
@@ -199,18 +204,20 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.edge_bound()
     }
 
-    pub fn endpoints(&self, index: &G::EdgeIndex) -> Option<(G::VertexIndex, G::VertexIndex)>
+    pub fn endpoints<EI>(&self, index: EI) -> Option<(G::VertexIndex, G::VertexIndex)>
     where
         G: EdgesBase<Ty>,
+        EI: Borrow<G::EdgeIndex>,
     {
-        self.graph.endpoints(index)
+        self.graph.endpoints(index.borrow())
     }
 
-    pub fn edge_index(&self, src: &G::VertexIndex, dst: &G::VertexIndex) -> Option<G::EdgeIndex>
+    pub fn edge_index<VI>(&self, src: VI, dst: VI) -> Option<G::EdgeIndex>
     where
         G: EdgesBase<Ty>,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.edge_index(src, dst)
+        self.graph.edge_index(src.borrow(), dst.borrow())
     }
 
     pub fn edge_indices(&self) -> G::EdgeIndicesIter<'_>
@@ -220,11 +227,12 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.edge_indices()
     }
 
-    pub fn contains_edge(&self, index: &G::EdgeIndex) -> bool
+    pub fn contains_edge<EI>(&self, index: EI) -> bool
     where
         G: EdgesBase<Ty>,
+        EI: Borrow<G::EdgeIndex>,
     {
-        self.graph.contains_edge(index)
+        self.graph.contains_edge(index.borrow())
     }
 
     pub fn is_directed(&self) -> bool
@@ -234,11 +242,12 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.is_directed()
     }
 
-    pub fn edge(&self, index: &G::EdgeIndex) -> Option<&E>
+    pub fn edge<EI>(&self, index: EI) -> Option<&E>
     where
         G: Edges<E, Ty>,
+        EI: Borrow<G::EdgeIndex>,
     {
-        self.graph.edge(index)
+        self.graph.edge(index.borrow())
     }
 
     pub fn edges(&self) -> G::EdgesIter<'_>
@@ -248,32 +257,36 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.edges()
     }
 
-    pub fn edge_mut(&mut self, index: &G::EdgeIndex) -> Option<&mut E>
+    pub fn edge_mut<EI>(&mut self, index: EI) -> Option<&mut E>
     where
         G: EdgesMut<E, Ty>,
+        EI: Borrow<G::EdgeIndex>,
     {
-        self.graph.edge_mut(index)
+        self.graph.edge_mut(index.borrow())
     }
 
-    pub fn add_edge(&mut self, src: &G::VertexIndex, dst: &G::VertexIndex, edge: E) -> G::EdgeIndex
+    pub fn add_edge<VI>(&mut self, src: VI, dst: VI, edge: E) -> G::EdgeIndex
     where
         G: EdgesMut<E, Ty>,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.add_edge(src, dst, edge)
+        self.graph.add_edge(src.borrow(), dst.borrow(), edge)
     }
 
-    pub fn remove_edge(&mut self, index: &G::EdgeIndex) -> Option<E>
+    pub fn remove_edge<EI>(&mut self, index: EI) -> Option<E>
     where
         G: EdgesMut<E, Ty>,
+        EI: Borrow<G::EdgeIndex>,
     {
-        self.graph.remove_edge(index)
+        self.graph.remove_edge(index.borrow())
     }
 
-    pub fn replace_edge(&mut self, index: &G::EdgeIndex, edge: E) -> E
+    pub fn replace_edge<EI>(&mut self, index: EI, edge: E) -> E
     where
         G: EdgesMut<E, Ty>,
+        EI: Borrow<G::EdgeIndex>,
     {
-        self.graph.replace_edge(index, edge)
+        self.graph.replace_edge(index.borrow(), edge)
     }
 
     pub fn clear_edges(&mut self)
@@ -283,43 +296,44 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.clear_edges()
     }
 
-    pub fn multi_edge_index(
-        &self,
-        src: &G::VertexIndex,
-        dst: &G::VertexIndex,
-    ) -> G::MultiEdgeIndicesIter<'_>
+    pub fn multi_edge_index<VI>(&self, src: VI, dst: VI) -> G::MultiEdgeIndicesIter<'_>
     where
         G: MultiEdges<E, Ty>,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.multi_edge_index(src, dst)
+        self.graph.multi_edge_index(src.borrow(), dst.borrow())
     }
 
-    pub fn neighbors(&self, src: &G::VertexIndex) -> G::NeighborsIter<'_>
+    pub fn neighbors<VI>(&self, src: VI) -> G::NeighborsIter<'_>
     where
         G: Neighbors,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.neighbors(src)
+        self.graph.neighbors(src.borrow())
     }
 
-    pub fn neighbors_directed(&self, src: &G::VertexIndex, dir: Direction) -> G::NeighborsIter<'_>
+    pub fn neighbors_directed<VI>(&self, src: VI, dir: Direction) -> G::NeighborsIter<'_>
     where
         G: Neighbors,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.neighbors_directed(src, dir)
+        self.graph.neighbors_directed(src.borrow(), dir)
     }
 
-    pub fn degree(&self, src: &G::VertexIndex) -> usize
+    pub fn degree<VI>(&self, src: VI) -> usize
     where
         G: Neighbors,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.degree(src)
+        self.graph.degree(src.borrow())
     }
 
-    pub fn degree_directed(&self, src: &G::VertexIndex, dir: Direction) -> usize
+    pub fn degree_directed<VI>(&self, src: VI, dir: Direction) -> usize
     where
         G: Neighbors,
+        VI: Borrow<G::VertexIndex>,
     {
-        self.graph.degree_directed(src, dir)
+        self.graph.degree_directed(src.borrow(), dir)
     }
 
     pub fn stabilize(self) -> Graph<V, E, Ty, Stable<G>>

--- a/src/graph/path.rs
+++ b/src/graph/path.rs
@@ -866,7 +866,7 @@ mod tests {
 
         let mut path = Path::<(), (), Undirected, _>::constrain(graph).unwrap();
 
-        let u = VertexIndex::from(42u64);
+        let u = VertexIndex::from(42);
 
         assert_matches!(
             path.try_add_vertex((), None, &u),

--- a/src/graph/path.rs
+++ b/src/graph/path.rs
@@ -1,13 +1,16 @@
+use std::hash::BuildHasherDefault;
 use std::marker::PhantomData;
 use std::ops::Deref;
 
-use crate::index::{EdgeIndex, IndexType, VertexIndex};
-use crate::infra::{CompactIndexMap, TypedBitSet, VisitSet};
+use rustc_hash::FxHashSet;
+
+use crate::index::{DefaultIndexing, NumIndexType};
+use crate::infra::{CompactIndexMap, VisitSet};
 use crate::marker::{Directed, Direction, EdgeType, Undirected};
 use crate::storage::{AdjList, Frozen, Stable};
 use crate::traits::*;
 use crate::{
-    Edges, EdgesBase, EdgesBaseWeak, EdgesWeak, Neighbors, Vertices, VerticesBase,
+    Edges, EdgesBase, EdgesBaseWeak, EdgesWeak, GraphBase, Neighbors, Vertices, VerticesBase,
     VerticesBaseWeak, VerticesWeak,
 };
 
@@ -15,6 +18,7 @@ use super::Graph;
 
 #[derive(
     Debug,
+    GraphBase,
     VerticesBase,
     Vertices,
     EdgesBase,
@@ -25,10 +29,13 @@ use super::Graph;
     EdgesBaseWeak,
     EdgesWeak,
 )]
-pub struct Path<V, E, Ty: EdgeType, G> {
+pub struct Path<V, E, Ty: EdgeType, G>
+where
+    G: GraphBase,
+{
     #[graph]
     graph: G,
-    ends: Option<[VertexIndex; 2]>,
+    ends: Option<[G::VertexIndex; 2]>,
     ty: PhantomData<(V, E, Ty)>,
 }
 
@@ -40,7 +47,7 @@ pub enum PathError {
     Direction,
 }
 
-impl<V, E, Ty: EdgeType> Path<V, E, Ty, AdjList<V, E, Ty>> {
+impl<V, E, Ty: EdgeType> Path<V, E, Ty, AdjList<V, E, Ty, DefaultIndexing>> {
     pub fn new() -> Self {
         Self::new_unchecked(AdjList::new(), None)
     }
@@ -50,13 +57,13 @@ impl<V, E, Ty: EdgeType> Path<V, E, Ty, AdjList<V, E, Ty>> {
     }
 }
 
-impl<V, E> Path<V, E, Undirected, AdjList<V, E, Undirected>> {
+impl<V, E> Path<V, E, Undirected, AdjList<V, E, Undirected, DefaultIndexing>> {
     pub fn new_undirected() -> Self {
         Self::new_unchecked(AdjList::new(), None)
     }
 }
 
-impl<V, E> Path<V, E, Directed, AdjList<V, E, Directed>> {
+impl<V, E> Path<V, E, Directed, AdjList<V, E, Directed, DefaultIndexing>> {
     pub fn new_directed() -> Self {
         Self::new_unchecked(AdjList::new(), None)
     }
@@ -64,15 +71,18 @@ impl<V, E> Path<V, E, Directed, AdjList<V, E, Directed>> {
 
 impl<V, E, Ty: EdgeType, G> Default for Path<V, E, Ty, G>
 where
-    G: Default,
+    G: Default + GraphBase,
 {
     fn default() -> Self {
         Self::new_unchecked(G::default(), None)
     }
 }
 
-impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
-    fn new_unchecked(graph: G, ends: Option<[VertexIndex; 2]>) -> Self {
+impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G>
+where
+    G: GraphBase,
+{
+    fn new_unchecked(graph: G, ends: Option<[G::VertexIndex; 2]>) -> Self {
         Self {
             graph,
             ends,
@@ -80,7 +90,7 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
         }
     }
 
-    fn check_runtime(graph: &G) -> Result<Option<[VertexIndex; 2]>, PathError>
+    fn check_runtime(graph: &G) -> Result<Option<[G::VertexIndex; 2]>, PathError>
     where
         G: Vertices<V> + Neighbors,
     {
@@ -90,54 +100,62 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
             None => return Ok(None),
         };
 
-        let vertex_map = graph.vertex_index_map();
-        let mut visited = TypedBitSet::with_capacity(vertex_map.len());
+        let mut visited = FxHashSet::with_capacity_and_hasher(
+            graph.vertex_count(),
+            BuildHasherDefault::default(),
+        );
 
-        visited.visit(v);
+        visited.visit(v.clone());
 
-        let mut check_segment =
-            |mut v: VertexIndex, mut prev: VertexIndex| -> Result<VertexIndex, PathError> {
-                visited.visit(v);
+        let mut check_segment = |mut v: G::VertexIndex,
+                                 mut prev: G::VertexIndex|
+         -> Result<G::VertexIndex, PathError> {
+            visited.visit(v.clone());
 
-                loop {
-                    match graph.degree(v) {
-                        1 => return Ok(v),
-                        2 => {
-                            let u = graph
-                                .neighbors(v)
-                                .find(|n| n.index() != prev)
-                                .ok_or(PathError::Cycle)?
-                                .index();
+            loop {
+                match graph.degree(&v) {
+                    1 => return Ok(v),
+                    2 => {
+                        let u = graph
+                            .neighbors(&v)
+                            .find(|n| n.index().as_ref() != &prev)
+                            .ok_or(PathError::Cycle)?
+                            .index()
+                            .into_owned();
 
-                            if visited.visit(u) {
-                                prev = v;
-                                v = u;
-                            } else {
-                                return Err(PathError::Cycle);
-                            }
+                        if visited.visit(u.clone()) {
+                            prev = v;
+                            v = u;
+                        } else {
+                            return Err(PathError::Cycle);
                         }
-                        _ => return Err(PathError::HigherDegree),
                     }
+                    _ => return Err(PathError::HigherDegree),
                 }
-            };
+            }
+        };
 
         // Based on what vertex we picked, check the rest of the path from an
         // end or both segments from the middle.
-        let mut ends = match graph.degree(v) {
+        let mut ends = match graph.degree(&v) {
             0 => {
                 // Isolated vertex.
-                [v, v]
+                [v.clone(), v]
             }
             1 => {
-                let u = check_segment(graph.neighbors(v).next().unwrap().index(), v)?;
+                let u = check_segment(
+                    graph.neighbors(&v).next().unwrap().index().into_owned(),
+                    v.clone(),
+                )?;
                 [v, u]
             }
             2 => {
-                let mut ends = [VertexIndex::null(); 2];
-                for (u, end) in graph.neighbors(v).zip(ends.iter_mut()) {
-                    *end = check_segment(u.index(), v)?;
-                }
-                ends
+                let mut iter = graph.neighbors(&v);
+                let u = iter.next().unwrap();
+                let u1 = check_segment(u.index().into_owned(), v.clone())?;
+                let u = iter.next().unwrap();
+                let u2 = check_segment(u.index().into_owned(), v)?;
+                [u1, u2]
             }
             _ => return Err(PathError::HigherDegree),
         };
@@ -147,13 +165,13 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
         }
 
         if Ty::is_directed() {
-            let start = if graph.degree_directed(ends[0], Direction::Outgoing) == 1 {
-                ends[0]
-            } else if graph.degree_directed(ends[1], Direction::Outgoing) == 1 {
+            let start = if graph.degree_directed(&ends[0], Direction::Outgoing) == 1 {
+                ends[0].clone()
+            } else if graph.degree_directed(&ends[1], Direction::Outgoing) == 1 {
                 // In directed paths, the first end is always with in-degree 0
                 // and the second end is with out-degree 0.
                 ends.swap(0, 1);
-                ends[0]
+                ends[0].clone()
             } else {
                 return Err(PathError::Direction);
             };
@@ -162,11 +180,11 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
 
             let mut vertex = Some(start);
             while let Some(v) = vertex {
-                visited.visit(v);
                 vertex = graph
-                    .neighbors_directed(v, Direction::Outgoing)
+                    .neighbors_directed(&v, Direction::Outgoing)
                     .next()
-                    .map(|n| n.index());
+                    .map(|n| n.index().into_owned());
+                visited.visit(v);
             }
 
             if visited.visited_count() != graph.vertex_count() {
@@ -198,21 +216,21 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
         self.graph.vertex_indices()
     }
 
-    pub fn vertex(&self, index: VertexIndex) -> Option<&V>
+    pub fn vertex(&self, index: &G::VertexIndex) -> Option<&V>
     where
         G: Vertices<V>,
     {
         self.graph.vertex(index)
     }
 
-    pub fn vertices(&self) -> G::VerticesIter<'_, V>
+    pub fn vertices(&self) -> G::VerticesIter<'_>
     where
         G: Vertices<V>,
     {
         self.graph.vertices()
     }
 
-    pub fn vertex_mut(&mut self, index: VertexIndex) -> Option<&mut V>
+    pub fn vertex_mut(&mut self, index: &G::VertexIndex) -> Option<&mut V>
     where
         G: VerticesMut<V>,
     {
@@ -223,8 +241,8 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
         &mut self,
         vertex: V,
         edge: Option<E>,
-        end: VertexIndex,
-    ) -> Result<VertexIndex, PathError>
+        end: &G::VertexIndex,
+    ) -> Result<G::VertexIndex, PathError>
     where
         G: VerticesMut<V> + EdgesMut<E, Ty> + Neighbors,
     {
@@ -235,9 +253,9 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
                     // the new vertex. This is just for satisfying irrational
                     // feeling that growing the path from the isolated vertex
                     // should change the "second" end, not the "first".
-                    [_, u] | [u, _] if *u == end => u,
+                    [_, u] | [u, _] if u == end => u,
                     _ => {
-                        let error = if self.graph.vertex_indices().any(|v| v == end) {
+                        let error = if self.graph.vertex_indices().any(|v| &v == end) {
                             PathError::HigherDegree
                         } else {
                             PathError::Disconnected
@@ -248,9 +266,9 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
 
                 let edge = edge.ok_or(PathError::Disconnected)?;
 
-                let u = *end;
+                let u = end.clone();
                 let v = self.graph.add_vertex(vertex);
-                *end = v;
+                *end = v.clone();
 
                 let (u, v) = if Ty::is_directed() {
                     // For directed graph, the edge must have the correct
@@ -264,47 +282,48 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
                     (u, v)
                 };
 
-                self.graph.add_edge(u, v, edge);
+                self.graph.add_edge(&u, &v, edge);
 
                 Ok(v)
             }
             None => {
                 let v = self.graph.add_vertex(vertex);
-                self.ends = Some([v, v]);
+                self.ends = Some([v.clone(), v.clone()]);
                 Ok(v)
             }
         }
     }
 
-    pub fn add_vertex(&mut self, vertex: V, end: VertexIndex) -> VertexIndex
+    pub fn add_vertex(&mut self, vertex: V, end: &G::VertexIndex) -> G::VertexIndex
     where
         E: Default,
         G: VerticesMut<V> + EdgesMut<E, Ty> + Neighbors,
     {
         // Check if end is valid. If not, ignore the passed value and pick an
         // arbitrary real end.
-        let end = match self.ends {
+        let end = match self.ends.as_ref() {
             // Provided end is valid.
-            Some([u, _]) | Some([_, u]) if u == end => end,
+            Some([u, _]) | Some([_, u]) if u == end => end.clone(),
             // Provided end is invalid, pick an arbitrary end.
-            Some([u, _]) => u,
-            // The graph is empty.
-            None => VertexIndex::null(),
+            Some([u, _]) => u.clone(),
+            // The graph is empty. We can use whatever end because it will *not*
+            // be used in `try_add_vertex` anyway.
+            None => end.clone(),
         };
 
         // We made sure that we provide all necessary, correct inputs so that
         // `try_add_vertex` cannot fail.
-        self.try_add_vertex(vertex, Some(E::default()), end)
+        self.try_add_vertex(vertex, Some(E::default()), &end)
             .unwrap()
     }
 
-    pub fn remove_vertex(&mut self, index: VertexIndex, edge: Option<E>) -> Option<V>
+    pub fn remove_vertex(&mut self, index: &G::VertexIndex, edge: Option<E>) -> Option<V>
     where
         G: VerticesMut<V> + EdgesMut<E, Ty> + Neighbors,
     {
         match self.ends.as_mut() {
             Some(ends) if ends[0] == ends[1] => {
-                if ends[0] == index {
+                if &ends[0] == index {
                     self.ends = None;
                     self.graph.remove_vertex(index)
                 } else {
@@ -312,9 +331,15 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
                 }
             }
             Some(ends) => match ends {
-                [end, _] | [_, end] if *end == index => {
+                [end, _] | [_, end] if end == index => {
                     // The removed vertex is an end.
-                    *end = self.graph.neighbors(index).next().unwrap().index();
+                    *end = self
+                        .graph
+                        .neighbors(index)
+                        .next()
+                        .unwrap()
+                        .index()
+                        .into_owned();
                     self.graph.remove_vertex(index)
                 }
                 _ => {
@@ -325,18 +350,20 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
                             .neighbors_directed(index, Direction::Incoming)
                             .next()
                             .unwrap()
-                            .index();
+                            .index()
+                            .into_owned();
                         let v = self
                             .graph
                             .neighbors_directed(index, Direction::Outgoing)
                             .next()
                             .unwrap()
-                            .index();
+                            .index()
+                            .into_owned();
                         (u, v)
                     } else {
                         let mut neighbors = self.graph.neighbors(index);
-                        let u = neighbors.next().unwrap().index();
-                        let v = neighbors.next().unwrap().index();
+                        let u = neighbors.next().unwrap().index().into_owned();
+                        let v = neighbors.next().unwrap().index().into_owned();
                         (u, v)
                     };
 
@@ -344,12 +371,18 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
                         // An edge to connect vertices was not provided, we will
                         // reuse an edge that was between the removed vertex and
                         // one of its neighbors.
-                        let e = self.graph.neighbors(index).next().unwrap().edge();
-                        self.graph.remove_edge(e).unwrap()
+                        let e = self
+                            .graph
+                            .neighbors(index)
+                            .next()
+                            .unwrap()
+                            .edge()
+                            .into_owned();
+                        self.graph.remove_edge(&e).unwrap()
                     });
 
                     // Connect the neighbors of the removed vertex.
-                    self.graph.add_edge(u, v, edge);
+                    self.graph.add_edge(&u, &v, edge);
 
                     self.graph.remove_vertex(index)
                 }
@@ -358,7 +391,7 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
         }
     }
 
-    pub fn replace_vertex(&mut self, index: VertexIndex, vertex: V) -> V
+    pub fn replace_vertex(&mut self, index: &G::VertexIndex, vertex: V) -> V
     where
         G: VerticesMut<V>,
     {
@@ -387,14 +420,14 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
         self.graph.edge_bound()
     }
 
-    pub fn endpoints(&self, index: EdgeIndex) -> Option<(VertexIndex, VertexIndex)>
+    pub fn endpoints(&self, index: &G::EdgeIndex) -> Option<(G::VertexIndex, G::VertexIndex)>
     where
         G: EdgesBase<Ty>,
     {
         self.graph.endpoints(index)
     }
 
-    pub fn edge_index(&self, src: VertexIndex, dst: VertexIndex) -> Option<EdgeIndex>
+    pub fn edge_index(&self, src: &G::VertexIndex, dst: &G::VertexIndex) -> Option<G::EdgeIndex>
     where
         G: EdgesBase<Ty>,
     {
@@ -408,7 +441,7 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
         self.graph.edge_indices()
     }
 
-    pub fn contains_edge(&self, index: EdgeIndex) -> bool
+    pub fn contains_edge(&self, index: &G::EdgeIndex) -> bool
     where
         G: EdgesBase<Ty>,
     {
@@ -422,64 +455,64 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
         self.graph.is_directed()
     }
 
-    pub fn edge(&self, index: EdgeIndex) -> Option<&E>
+    pub fn edge(&self, index: &G::EdgeIndex) -> Option<&E>
     where
         G: Edges<E, Ty>,
     {
         self.graph.edge(index)
     }
 
-    pub fn edges(&self) -> G::EdgesIter<'_, E>
+    pub fn edges(&self) -> G::EdgesIter<'_>
     where
         G: Edges<E, Ty>,
     {
         self.graph.edges()
     }
 
-    pub fn edge_mut(&mut self, index: EdgeIndex) -> Option<&mut E>
+    pub fn edge_mut(&mut self, index: &G::EdgeIndex) -> Option<&mut E>
     where
         G: EdgesMut<E, Ty>,
     {
         self.graph.edge_mut(index)
     }
 
-    pub fn replace_edge(&mut self, index: EdgeIndex, edge: E) -> E
+    pub fn replace_edge(&mut self, index: &G::EdgeIndex, edge: E) -> E
     where
         G: EdgesMut<E, Ty>,
     {
         self.graph.replace_edge(index, edge)
     }
 
-    pub fn neighbors(&self, src: VertexIndex) -> G::NeighborsIter<'_>
+    pub fn neighbors(&self, src: &G::VertexIndex) -> G::NeighborsIter<'_>
     where
         G: Neighbors,
     {
         self.graph.neighbors(src)
     }
 
-    pub fn neighbors_directed(&self, src: VertexIndex, dir: Direction) -> G::NeighborsIter<'_>
+    pub fn neighbors_directed(&self, src: &G::VertexIndex, dir: Direction) -> G::NeighborsIter<'_>
     where
         G: Neighbors,
     {
         self.graph.neighbors_directed(src, dir)
     }
 
-    pub fn degree(&self, src: VertexIndex) -> usize
+    pub fn degree(&self, src: &G::VertexIndex) -> usize
     where
         G: Neighbors,
     {
         self.graph.degree(src)
     }
 
-    pub fn degree_directed(&self, src: VertexIndex, dir: Direction) -> usize
+    pub fn degree_directed(&self, src: &G::VertexIndex, dir: Direction) -> usize
     where
         G: Neighbors,
     {
         self.graph.degree_directed(src, dir)
     }
 
-    pub fn ends(&self) -> Option<[VertexIndex; 2]> {
-        self.ends
+    pub fn ends(&self) -> Option<&[G::VertexIndex; 2]> {
+        self.ends.as_ref()
     }
 
     pub fn stabilize(self) -> Path<V, E, Ty, Stable<G>> {
@@ -491,7 +524,10 @@ impl<V, E, Ty: EdgeType, G> Path<V, E, Ty, G> {
     }
 }
 
-impl<V, E, Ty: EdgeType, G> From<Path<V, E, Ty, G>> for Graph<V, E, Ty, G> {
+impl<V, E, Ty: EdgeType, G> From<Path<V, E, Ty, G>> for Graph<V, E, Ty, G>
+where
+    G: GraphBase,
+{
     fn from(path: Path<V, E, Ty, G>) -> Self {
         Graph::with_storage(path.graph)
     }
@@ -520,7 +556,10 @@ where
     }
 }
 
-impl<V, E, Ty: EdgeType, G> Deref for Path<V, E, Ty, G> {
+impl<V, E, Ty: EdgeType, G> Deref for Path<V, E, Ty, G>
+where
+    G: GraphBase,
+{
     type Target = G;
 
     fn deref(&self) -> &Self::Target {
@@ -528,7 +567,10 @@ impl<V, E, Ty: EdgeType, G> Deref for Path<V, E, Ty, G> {
     }
 }
 
-impl<V, E, Ty: EdgeType, G> Guarantee for Path<V, E, Ty, G> {
+impl<V, E, Ty: EdgeType, G> Guarantee for Path<V, E, Ty, G>
+where
+    G: GraphBase,
+{
     fn is_loop_free() -> bool {
         true
     }
@@ -546,19 +588,19 @@ impl<V, E, Ty: EdgeType, G> Guarantee for Path<V, E, Ty, G> {
 mod tests {
     use std::assert_matches::assert_matches;
 
-    use crate::storage::AdjList;
+    use crate::{index::VertexIndex, storage::AdjList};
 
     use super::*;
 
     #[test]
     fn check_empty() {
-        let graph: AdjList<(), (), Undirected> = AdjList::new();
+        let graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
         assert!(Path::<(), (), Undirected, _>::check(&graph).is_ok());
     }
 
     #[test]
     fn check_isolated() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         graph.add_vertex(());
 
@@ -567,60 +609,60 @@ mod tests {
 
     #[test]
     fn check_from_end() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v1, v2, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v1, &v2, ());
 
         assert!(Path::<(), (), Undirected, _>::check(&graph).is_ok());
     }
 
     #[test]
     fn check_from_middle() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v0, v2, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v0, &v2, ());
 
         assert!(Path::<(), (), Undirected, _>::check(&graph).is_ok());
     }
 
     #[test]
     fn check_directed() {
-        let mut graph: AdjList<(), (), Directed> = AdjList::new();
+        let mut graph: AdjList<(), (), Directed, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
 
-        graph.add_edge(v2, v1, ());
-        graph.add_edge(v1, v0, ());
+        graph.add_edge(&v2, &v1, ());
+        graph.add_edge(&v1, &v0, ());
 
         let path = Path::<(), (), Directed, _>::constrain(graph);
         assert!(path.is_ok());
-        assert_eq!(path.unwrap().ends(), Some([v2, v0]));
+        assert_eq!(path.unwrap().ends(), Some(&[v2, v0]));
     }
 
     #[test]
     fn check_from_end_higher_degree() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
         let v3 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v1, v2, ());
-        graph.add_edge(v1, v3, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v1, &v2, ());
+        graph.add_edge(&v1, &v3, ());
 
         assert_matches!(
             Path::<(), (), Undirected, _>::check(&graph),
@@ -630,16 +672,16 @@ mod tests {
 
     #[test]
     fn check_from_middle_higher_degree() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
         let v3 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v0, v2, ());
-        graph.add_edge(v0, v3, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v0, &v2, ());
+        graph.add_edge(&v0, &v3, ());
 
         assert_matches!(
             Path::<(), (), Undirected, _>::check(&graph),
@@ -649,7 +691,7 @@ mod tests {
 
     #[test]
     fn check_from_any_higher_degree() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
@@ -657,10 +699,10 @@ mod tests {
         let v3 = graph.add_vertex(());
         let v4 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v0, v2, ());
-        graph.add_edge(v1, v3, ());
-        graph.add_edge(v1, v4, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v0, &v2, ());
+        graph.add_edge(&v1, &v3, ());
+        graph.add_edge(&v1, &v4, ());
 
         assert_matches!(
             Path::<(), (), Undirected, _>::check(&graph),
@@ -670,17 +712,17 @@ mod tests {
 
     #[test]
     fn check_cycle() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
         let v3 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v1, v2, ());
-        graph.add_edge(v2, v3, ());
-        graph.add_edge(v3, v0, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v1, &v2, ());
+        graph.add_edge(&v2, &v3, ());
+        graph.add_edge(&v3, &v0, ());
 
         assert_matches!(
             Path::<(), (), Undirected, _>::check(&graph),
@@ -690,17 +732,17 @@ mod tests {
 
     #[test]
     fn check_multigraph() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
         let v3 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v1, v2, ());
-        graph.add_edge(v2, v1, ());
-        graph.add_edge(v2, v3, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v1, &v2, ());
+        graph.add_edge(&v2, &v1, ());
+        graph.add_edge(&v2, &v3, ());
 
         assert_matches!(
             Path::<(), (), Undirected, _>::check(&graph),
@@ -710,15 +752,15 @@ mod tests {
 
     #[test]
     fn check_disconnected() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
         let v3 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v2, v3, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v2, &v3, ());
 
         assert_matches!(
             Path::<(), (), Undirected, _>::check(&graph),
@@ -728,13 +770,13 @@ mod tests {
 
     #[test]
     fn check_self_loop() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v1, v1, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v1, &v1, ());
 
         assert_matches!(
             Path::<(), (), Undirected, _>::check(&graph),
@@ -744,11 +786,11 @@ mod tests {
 
     #[test]
     fn check_self_loop_isolated() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
 
-        graph.add_edge(v0, v0, ());
+        graph.add_edge(&v0, &v0, ());
 
         assert_matches!(
             Path::<(), (), Undirected, _>::check(&graph),
@@ -758,16 +800,16 @@ mod tests {
 
     #[test]
     fn check_direction() {
-        let mut graph: AdjList<(), (), Directed> = AdjList::new();
+        let mut graph: AdjList<(), (), Directed, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
         let v3 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v2, v1, ());
-        graph.add_edge(v2, v3, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v2, &v1, ());
+        graph.add_edge(&v2, &v3, ());
 
         assert_matches!(
             Path::<(), (), Directed, _>::check(&graph),
@@ -777,14 +819,14 @@ mod tests {
 
     #[test]
     fn check_direction_ends() {
-        let mut graph: AdjList<(), (), Directed> = AdjList::new();
+        let mut graph: AdjList<(), (), Directed, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
 
-        graph.add_edge(v1, v0, ());
-        graph.add_edge(v1, v2, ());
+        graph.add_edge(&v1, &v0, ());
+        graph.add_edge(&v1, &v2, ());
 
         assert_matches!(
             Path::<(), (), Directed, _>::check(&graph),
@@ -794,54 +836,54 @@ mod tests {
 
     #[test]
     fn try_add_vertex_middle() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v1, v2, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v1, &v2, ());
 
         let mut path = Path::<(), (), Undirected, _>::constrain(graph).unwrap();
 
         assert_matches!(
-            path.try_add_vertex((), None, v1),
+            path.try_add_vertex((), None, &v1),
             Err(PathError::HigherDegree)
         );
     }
 
     #[test]
     fn try_add_vertex_non_existent() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v1, v2, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v1, &v2, ());
 
         let mut path = Path::<(), (), Undirected, _>::constrain(graph).unwrap();
 
-        let u = VertexIndex::from(42);
+        let u = VertexIndex::from(42u64);
 
         assert_matches!(
-            path.try_add_vertex((), None, u),
+            path.try_add_vertex((), None, &u),
             Err(PathError::Disconnected)
         );
     }
 
     #[test]
     fn try_add_vertex_no_edge() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
 
         let mut path = Path::<(), (), Undirected, _>::constrain(graph).unwrap();
 
         assert_matches!(
-            path.try_add_vertex((), None, v0),
+            path.try_add_vertex((), None, &v0),
             Err(PathError::Disconnected)
         );
     }
@@ -850,55 +892,49 @@ mod tests {
     fn try_add_vertex_empty() {
         let mut path = Path::<(), (), Undirected, _>::new();
 
-        let result = path.try_add_vertex((), None, VertexIndex::null());
+        let result = path.try_add_vertex((), None, &VertexIndex::null());
         assert!(result.is_ok());
 
         let v = result.unwrap();
-        assert!(path.ends().is_some());
-        assert_eq!(path.ends().unwrap()[0], v);
-        assert_eq!(path.ends().unwrap()[1], v);
+        assert_eq!(path.ends(), Some(&[v, v]));
     }
 
     #[test]
     fn try_add_vertex_isolated() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
 
         let mut path = Path::<(), (), Undirected, _>::constrain(graph).unwrap();
 
-        let result = path.try_add_vertex((), Some(()), v0);
+        let result = path.try_add_vertex((), Some(()), &v0);
         assert!(result.is_ok());
 
         let v = result.unwrap();
-        assert!(path.ends().is_some());
-        assert_eq!(path.ends().unwrap()[0], v0);
-        assert_eq!(path.ends().unwrap()[1], v);
+        assert_eq!(path.ends(), Some(&[v0, v]));
 
-        assert!(path.edge_index(v0, v).is_some());
+        assert!(path.edge_index(&v0, &v).is_some());
     }
 
     #[test]
     fn try_add_vertex() {
-        let mut graph: AdjList<(), (), Undirected> = AdjList::new();
+        let mut graph: AdjList<(), (), Undirected, DefaultIndexing> = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
+        graph.add_edge(&v0, &v1, ());
 
         let mut path = Path::<(), (), Undirected, _>::constrain(graph).unwrap();
 
-        let [v0, v1] = path.ends().unwrap();
+        let [v0, v1] = *path.ends().unwrap();
 
-        let result = path.try_add_vertex((), Some(()), v1);
+        let result = path.try_add_vertex((), Some(()), &v1);
         assert!(result.is_ok());
 
         let v = result.unwrap();
-        assert!(path.ends().is_some());
-        assert_eq!(path.ends().unwrap()[0], v0);
-        assert_eq!(path.ends().unwrap()[1], v);
+        assert_eq!(path.ends(), Some(&[v0, v]));
 
-        assert!(path.edge_index(v1, v).is_some());
+        assert!(path.edge_index(&v1, &v).is_some());
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,22 +1,26 @@
-use std::hash::Hash;
-use std::marker::PhantomData;
+use std::{hash::Hash, marker::PhantomData};
 
-pub trait IndexType:
-    Clone + Copy + PartialEq + Eq + PartialOrd + Ord + Hash + private::Sealed
-{
-    fn from_bits(bits: u64) -> Self;
-    fn to_bits(self) -> u64;
+pub trait IndexType: Clone + PartialEq + PartialOrd + Ord + Hash {}
 
-    fn new(index: usize) -> Self {
-        Self::from_bits(index as u64)
+pub trait NumIndexType: IndexType + Copy + From<u64> + Into<u64> {
+    fn to_bits(self) -> u64 {
+        self.into()
     }
 
-    fn to_usize(self) -> usize {
-        self.to_bits() as usize
+    fn from_bits(bits: u64) -> Self {
+        bits.into()
+    }
+
+    fn as_usize(self) -> usize {
+        self.to_bits().try_into().expect("index type overflow")
+    }
+
+    fn from_usize(index: usize) -> Self {
+        (index as u64).into()
     }
 
     fn null() -> Self {
-        Self::new(usize::MAX)
+        u64::MAX.into()
     }
 
     fn is_null(&self) -> bool {
@@ -24,87 +28,136 @@ pub trait IndexType:
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct VertexIndex(u64);
-
-impl IndexType for VertexIndex {
-    fn from_bits(bits: u64) -> Self {
-        Self(bits)
-    }
-
-    fn to_bits(self) -> u64 {
-        self.0
-    }
-}
-
-impl Default for VertexIndex {
-    fn default() -> Self {
-        Self::null()
-    }
-}
-
-impl From<usize> for VertexIndex {
-    fn from(index: usize) -> Self {
-        Self::new(index)
-    }
-}
+// For edge indices that are represented as a pair of vertex indices.
+impl<T: IndexType, U: IndexType> IndexType for (T, U) {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EdgeIndex(u64);
+pub struct VertexIndex<Ix = u64>(pub Ix);
 
-impl IndexType for EdgeIndex {
-    fn from_bits(bits: u64) -> Self {
-        Self(bits)
-    }
-
-    fn to_bits(self) -> u64 {
-        self.0
-    }
-}
-
-impl Default for EdgeIndex {
-    fn default() -> Self {
-        Self::null()
-    }
-}
-
-impl From<usize> for EdgeIndex {
-    fn from(index: usize) -> Self {
-        Self::new(index)
-    }
-}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EdgeIndex<Ix = u64>(pub Ix);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Virtual<I>(u64, PhantomData<I>);
 
-impl<I: IndexType> IndexType for Virtual<I> {
-    fn from_bits(bits: u64) -> Self {
-        Self(bits, PhantomData)
-    }
-
-    fn to_bits(self) -> u64 {
-        self.0
+impl<I> Virtual<I> {
+    pub fn new(index: u64) -> Self {
+        Self(index, PhantomData)
     }
 }
 
-impl<I: IndexType + Default> Default for Virtual<I> {
-    fn default() -> Self {
-        Self::new(I::default().to_usize())
-    }
-}
+impl<I: IndexType> IndexType for Virtual<I> {}
 
-impl<I: IndexType> From<usize> for Virtual<I> {
+impl<I: NumIndexType> From<usize> for Virtual<I> {
     fn from(index: usize) -> Self {
+        Self::new(index.try_into().expect("index type overflow"))
+    }
+}
+
+impl<I: NumIndexType> From<Virtual<I>> for usize {
+    fn from(index: Virtual<I>) -> Self {
+        index.0.try_into().expect("index type overflow")
+    }
+}
+
+impl<I: NumIndexType> From<u64> for Virtual<I> {
+    fn from(index: u64) -> Self {
         Self::new(index)
     }
 }
 
-mod private {
+impl<I: NumIndexType> From<Virtual<I>> for u64 {
+    fn from(index: Virtual<I>) -> Self {
+        index.0
+    }
+}
+
+impl<I: NumIndexType> NumIndexType for Virtual<I> {}
+
+pub trait Indexing {
+    type VertexIndex: IndexType;
+    type EdgeIndex: IndexType;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum DefaultIndexing {}
+
+impl Indexing for DefaultIndexing {
+    type VertexIndex = VertexIndex;
+    type EdgeIndex = EdgeIndex;
+}
+
+pub struct CustomIndexing<VIx, EIx> {
+    ty: PhantomData<fn() -> (VIx, EIx)>,
+}
+
+impl<VIx: IndexType, EIx: IndexType> Indexing for CustomIndexing<VIx, EIx> {
+    type VertexIndex = VIx;
+    type EdgeIndex = EIx;
+}
+
+pub trait UseIndex<Ix: Indexing> {
+    type Index: IndexType;
+}
+
+pub enum UseVertexIndex {}
+
+impl<Ix: Indexing> UseIndex<Ix> for UseVertexIndex {
+    type Index = Ix::VertexIndex;
+}
+
+pub enum UseEdgeIndex {}
+
+impl<Ix: Indexing> UseIndex<Ix> for UseEdgeIndex {
+    type Index = Ix::EdgeIndex;
+}
+
+mod imp {
     use super::*;
 
-    pub trait Sealed {}
+    macro_rules! impl_num_index {
+        ($index_ty:ident, $int_ty:ty) => {
+            impl IndexType for $index_ty<$int_ty> {}
 
-    impl Sealed for VertexIndex {}
-    impl Sealed for EdgeIndex {}
-    impl<I> Sealed for Virtual<I> {}
+            impl From<usize> for $index_ty<$int_ty> {
+                fn from(index: usize) -> Self {
+                    Self(index.try_into().expect("index type overflow"))
+                }
+            }
+
+            impl From<$index_ty<$int_ty>> for usize {
+                fn from(index: $index_ty<$int_ty>) -> Self {
+                    index.0.try_into().expect("index type overflow")
+                }
+            }
+
+            impl From<u64> for $index_ty<$int_ty> {
+                fn from(index: u64) -> Self {
+                    Self(index.try_into().expect("index type overflow"))
+                }
+            }
+
+            impl From<$index_ty<$int_ty>> for u64 {
+                fn from(index: $index_ty<$int_ty>) -> Self {
+                    index.0.try_into().expect("index type overflow")
+                }
+            }
+
+            impl NumIndexType for $index_ty<$int_ty> {}
+        };
+    }
+
+    impl_num_index!(VertexIndex, usize);
+    impl_num_index!(VertexIndex, u64);
+    impl_num_index!(VertexIndex, u32);
+    impl_num_index!(VertexIndex, u16);
+    impl_num_index!(VertexIndex, u8);
+
+    impl_num_index!(EdgeIndex, usize);
+    impl_num_index!(EdgeIndex, u64);
+    impl_num_index!(EdgeIndex, u32);
+    impl_num_index!(EdgeIndex, u16);
+    impl_num_index!(EdgeIndex, u8);
+
+    impl IndexType for () {}
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,6 +1,6 @@
 use std::{hash::Hash, marker::PhantomData};
 
-pub trait IndexType: Clone + PartialEq + PartialOrd + Ord + Hash {}
+pub trait IndexType: Clone + PartialEq + PartialOrd + Ord + Hash + core::fmt::Debug {}
 
 pub trait NumIndexType: IndexType + Copy + From<usize> + Into<usize> {
     fn to_bits(self) -> u64;

--- a/src/infra/visit_set.rs
+++ b/src/infra/visit_set.rs
@@ -55,14 +55,14 @@ impl<I: IndexType, S: BuildHasher> VisitSet<I> for HashSet<I, S> {
 
 impl<I: NumIndexType> VisitSet<I> for FixedBitSet {
     fn visit(&mut self, index: I) -> bool {
-        if self.len() < index.as_usize() {
-            self.grow(index.as_usize() - self.len());
+        if self.len() < index.to_usize() {
+            self.grow(index.to_usize() - self.len());
         }
-        !self.put(index.as_usize())
+        !self.put(index.to_usize())
     }
 
     fn is_visited(&self, index: &I) -> bool {
-        self.contains(index.as_usize())
+        self.contains(index.to_usize())
     }
 
     fn visited_count(&self) -> usize {

--- a/src/infra/visit_set.rs
+++ b/src/infra/visit_set.rs
@@ -5,11 +5,14 @@ use std::{
 
 use fixedbitset::FixedBitSet;
 
-use crate::{index::IndexType, infra::TypedBitSet};
+use crate::{
+    index::{IndexType, NumIndexType},
+    infra::TypedBitSet,
+};
 
 pub trait VisitSet<I: IndexType> {
     fn visit(&mut self, index: I) -> bool;
-    fn is_visited(&self, index: I) -> bool;
+    fn is_visited(&self, index: &I) -> bool;
     fn visited_count(&self) -> usize;
     fn reset_visited(&mut self);
 }
@@ -19,8 +22,8 @@ impl<I: IndexType> VisitSet<I> for BTreeSet<I> {
         self.insert(index)
     }
 
-    fn is_visited(&self, index: I) -> bool {
-        self.contains(&index)
+    fn is_visited(&self, index: &I) -> bool {
+        self.contains(index)
     }
 
     fn visited_count(&self) -> usize {
@@ -37,8 +40,8 @@ impl<I: IndexType, S: BuildHasher> VisitSet<I> for HashSet<I, S> {
         self.insert(index)
     }
 
-    fn is_visited(&self, index: I) -> bool {
-        self.contains(&index)
+    fn is_visited(&self, index: &I) -> bool {
+        self.contains(index)
     }
 
     fn visited_count(&self) -> usize {
@@ -50,16 +53,16 @@ impl<I: IndexType, S: BuildHasher> VisitSet<I> for HashSet<I, S> {
     }
 }
 
-impl<I: IndexType> VisitSet<I> for FixedBitSet {
+impl<I: NumIndexType> VisitSet<I> for FixedBitSet {
     fn visit(&mut self, index: I) -> bool {
-        if self.len() < index.to_usize() {
-            self.grow(index.to_usize() - self.len());
+        if self.len() < index.as_usize() {
+            self.grow(index.as_usize() - self.len());
         }
-        !self.put(index.to_usize())
+        !self.put(index.as_usize())
     }
 
-    fn is_visited(&self, index: I) -> bool {
-        self.contains(index.to_usize())
+    fn is_visited(&self, index: &I) -> bool {
+        self.contains(index.as_usize())
     }
 
     fn visited_count(&self) -> usize {
@@ -71,12 +74,12 @@ impl<I: IndexType> VisitSet<I> for FixedBitSet {
     }
 }
 
-impl<I: IndexType> VisitSet<I> for TypedBitSet<I> {
+impl<I: NumIndexType> VisitSet<I> for TypedBitSet<I> {
     fn visit(&mut self, index: I) -> bool {
         (**self).visit(index)
     }
 
-    fn is_visited(&self, index: I) -> bool {
+    fn is_visited(&self, index: &I) -> bool {
         (**self).is_visited(index)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 #![feature(generic_associated_types)]
-#![feature(associated_type_defaults)]
 #![feature(assert_matches)]
 #![feature(int_log)]
 #![feature(try_blocks)]
+#![feature(auto_traits)]
+#![feature(negative_impls)]
 
 pub mod algo;
 pub mod export;
@@ -19,8 +20,8 @@ pub mod visit;
 pub mod weight;
 
 pub use macros::{
-    Edges, EdgesBase, EdgesBaseWeak, EdgesMut, EdgesWeak, Guarantee, MultiEdges, Neighbors,
-    Vertices, VerticesBase, VerticesBaseWeak, VerticesMut, VerticesWeak,
+    Edges, EdgesBase, EdgesBaseWeak, EdgesMut, EdgesWeak, GraphBase, Guarantee, MultiEdges,
+    Neighbors, Vertices, VerticesBase, VerticesBaseWeak, VerticesMut, VerticesWeak,
 };
 
 #[cfg(feature = "arbitrary")]
@@ -31,7 +32,9 @@ pub mod proptest;
 
 pub mod testing;
 
-pub use index::{EdgeIndex, IndexType, VertexIndex, Virtual};
+pub use index::{
+    DefaultIndexing, EdgeIndex, IndexType, Indexing, NumIndexType, VertexIndex, Virtual,
+};
 
 pub mod prelude {
     pub use crate::graph::Graph;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 #![feature(assert_matches)]
 #![feature(int_log)]
 #![feature(try_blocks)]
-#![feature(auto_traits)]
-#![feature(negative_impls)]
 
 pub mod algo;
 pub mod export;

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -34,10 +34,10 @@ impl Direction {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Undirected {}
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Directed {}
 
 pub trait EdgeType: private::Sealed + 'static {

--- a/src/operator/complement.rs
+++ b/src/operator/complement.rs
@@ -53,14 +53,14 @@ where
 
             // Assumption: adding vertices to the result graph generates index
             // sequence going from zero with step 1.
-            debug_assert!(idx.as_usize() == cur, "unexpected behavior of `add_vertex`");
+            debug_assert!(idx.to_usize() == cur, "unexpected behavior of `add_vertex`");
         }
 
         for u in self.graph.vertex_indices() {
             for v in self.graph.vertex_indices() {
-                if u.as_usize() < v.as_usize() && self.graph.edge_index(&u, &v).is_none() {
-                    let u = NumIndexType::from_usize(vertex_map.virt(u).unwrap().as_usize());
-                    let v = NumIndexType::from_usize(vertex_map.virt(v).unwrap().as_usize());
+                if u < v && self.graph.edge_index(&u, &v).is_none() {
+                    let u = NumIndexType::from_usize(vertex_map.virt(u).unwrap().to_usize());
+                    let v = NumIndexType::from_usize(vertex_map.virt(v).unwrap().to_usize());
                     result.add_edge(&u, &v, self.edge.clone());
                 }
             }
@@ -270,10 +270,10 @@ mod tests {
 
         // XXX: Complement does not preserve the vertex indices when there are
         // holes. This would change if we implement an in-place algorithm.
-        let v0 = VertexIndex::from(0usize);
-        let v1 = VertexIndex::from(1usize);
-        let v2 = VertexIndex::from(2usize);
-        let v4 = VertexIndex::from(3usize);
+        let v0 = VertexIndex::from(0);
+        let v1 = VertexIndex::from(1);
+        let v2 = VertexIndex::from(2);
+        let v4 = VertexIndex::from(3);
 
         assert!(complement.edge_index(&v0, &v1).is_none());
         assert!(complement.edge_index(&v1, &v2).is_none());

--- a/src/operator/complement.rs
+++ b/src/operator/complement.rs
@@ -227,7 +227,7 @@ mod tests {
         assert_eq!(
             complement
                 .neighbors(&v0)
-                .map(|n| NeighborRef::<DefaultIndexing>::index(&n).into_owned())
+                .map(|n| n.index().into_owned())
                 .collect::<HashSet<VertexIndex>>(),
             vec![v2, v3].into_iter().collect()
         );
@@ -235,14 +235,14 @@ mod tests {
         assert_eq!(
             complement
                 .neighbors(&v2)
-                .map(|n| NeighborRef::<DefaultIndexing>::index(&n).into_owned())
+                .map(|n| n.index().into_owned())
                 .collect::<HashSet<_>>(),
             vec![v0].into_iter().collect()
         );
         assert_eq!(
             complement
                 .neighbors(&v3)
-                .map(|n| NeighborRef::<DefaultIndexing>::index(&n).into_owned())
+                .map(|n| n.index().into_owned())
                 .collect::<HashSet<_>>(),
             vec![v0].into_iter().collect()
         );

--- a/src/operator/transpose.rs
+++ b/src/operator/transpose.rs
@@ -1,15 +1,16 @@
 use super::OpOwned;
-use crate::index::{EdgeIndex, VertexIndex};
+use crate::index::{Indexing, NumIndexType};
 use crate::infra::CompactIndexMap;
 use crate::marker::{Directed, Direction, EdgeType};
 use crate::traits::*;
 use crate::{
-    EdgesBaseWeak, EdgesWeak, Guarantee, Vertices, VerticesBase, VerticesBaseWeak, VerticesMut,
-    VerticesWeak,
+    EdgesBaseWeak, EdgesWeak, GraphBase, Guarantee, Vertices, VerticesBase, VerticesBaseWeak,
+    VerticesMut, VerticesWeak,
 };
 
 #[derive(
     Debug,
+    GraphBase,
     VerticesBase,
     Vertices,
     VerticesMut,
@@ -39,19 +40,19 @@ where
 
 impl<E, G, S: Stability> OpOwned<G, (E, S)> for Transpose<G>
 where
-    G: EdgesMut<E, Directed> + StableIndices<EdgeIndex, S>,
+    G: EdgesMut<E, Directed> + StableIndices<G::EdgeIndex, S>,
 {
     fn apply(self) -> G {
         let mut graph = self.graph;
 
         let edges = graph
             .edges()
-            .map(|edge| (edge.src(), edge.index(), edge.dst()))
+            .map(|edge| (edge.src().clone(), edge.index().clone(), edge.dst().clone()))
             .collect::<Vec<_>>();
 
         for (src, index, dst) in edges {
-            let data = graph.remove_edge(index).unwrap();
-            graph.add_edge(dst, src, data);
+            let data = graph.remove_edge(&index).unwrap();
+            graph.add_edge(&dst, &src, data);
         }
 
         graph
@@ -74,11 +75,15 @@ where
         self.graph.edge_bound()
     }
 
-    fn endpoints(&self, index: EdgeIndex) -> Option<(VertexIndex, VertexIndex)> {
+    fn endpoints(&self, index: &Self::EdgeIndex) -> Option<(Self::VertexIndex, Self::VertexIndex)> {
         self.graph.endpoints(index).map(|(src, dst)| (dst, src))
     }
 
-    fn edge_index(&self, src: VertexIndex, dst: VertexIndex) -> Option<EdgeIndex> {
+    fn edge_index(
+        &self,
+        src: &Self::VertexIndex,
+        dst: &Self::VertexIndex,
+    ) -> Option<Self::EdgeIndex> {
         self.graph.edge_index(dst, src)
     }
 
@@ -86,11 +91,14 @@ where
         self.graph.edge_indices()
     }
 
-    fn contains_edge(&self, index: EdgeIndex) -> bool {
+    fn contains_edge(&self, index: &Self::EdgeIndex) -> bool {
         self.graph.contains_edge(index)
     }
 
-    fn edge_index_map(&self) -> CompactIndexMap<EdgeIndex> {
+    fn edge_index_map(&self) -> CompactIndexMap<G::EdgeIndex>
+    where
+        Self::EdgeIndex: NumIndexType,
+    {
         self.graph.edge_index_map()
     }
 }
@@ -99,19 +107,21 @@ impl<E, G> Edges<E, Directed> for Transpose<G>
 where
     G: Edges<E, Directed>,
 {
-    type EdgeRef<'a, T: 'a> = TransposeRef<G::EdgeRef<'a, T>>
+    type EdgeRef<'a> = TransposeRef<G::EdgeRef<'a>>
     where
-        Self: 'a;
+        Self: 'a,
+        E: 'a;
 
-    type EdgesIter<'a, T: 'a> = Iter<G::EdgesIter<'a, T>>
+    type EdgesIter<'a> = Iter<G::EdgesIter<'a>>
     where
-        Self: 'a;
+        Self: 'a,
+        E: 'a;
 
-    fn edge(&self, index: EdgeIndex) -> Option<&E> {
+    fn edge(&self, index: &Self::EdgeIndex) -> Option<&E> {
         self.graph.edge(index)
     }
 
-    fn edges(&self) -> Self::EdgesIter<'_, E> {
+    fn edges(&self) -> Self::EdgesIter<'_> {
         Iter(self.graph.edges())
     }
 }
@@ -128,30 +138,35 @@ where
     where
         Self: 'a;
 
-    fn neighbors(&self, src: VertexIndex) -> Self::NeighborsIter<'_> {
+    fn neighbors(&self, src: &Self::VertexIndex) -> Self::NeighborsIter<'_> {
         Iter(self.graph.neighbors(src))
     }
 
-    fn neighbors_directed(&self, src: VertexIndex, dir: Direction) -> Self::NeighborsIter<'_> {
+    fn neighbors_directed(
+        &self,
+        src: &Self::VertexIndex,
+        dir: Direction,
+    ) -> Self::NeighborsIter<'_> {
         Iter(self.graph.neighbors_directed(src, dir.opposite()))
     }
 
-    fn degree(&self, index: VertexIndex) -> usize {
+    fn degree(&self, index: &Self::VertexIndex) -> usize {
         self.graph.degree(index)
     }
 
-    fn degree_directed(&self, index: VertexIndex, dir: Direction) -> usize {
+    fn degree_directed(&self, index: &Self::VertexIndex, dir: Direction) -> usize {
         self.graph.degree_directed(index, dir.opposite())
     }
 }
 
 pub struct TransposeRef<R>(R);
 
-impl<E, R> EdgeRef<E> for TransposeRef<R>
+impl<Ix, E, R> EdgeRef<Ix, E> for TransposeRef<R>
 where
-    R: EdgeRef<E>,
+    Ix: Indexing,
+    R: EdgeRef<Ix, E>,
 {
-    fn index(&self) -> EdgeIndex {
+    fn index(&self) -> &Ix::EdgeIndex {
         self.0.index()
     }
 
@@ -159,28 +174,29 @@ where
         self.0.data()
     }
 
-    fn src(&self) -> VertexIndex {
+    fn src(&self) -> &Ix::VertexIndex {
         self.0.dst()
     }
 
-    fn dst(&self) -> VertexIndex {
+    fn dst(&self) -> &Ix::VertexIndex {
         self.0.src()
     }
 }
 
-impl<R> NeighborRef for TransposeRef<R>
+impl<Ix, R> NeighborRef<Ix> for TransposeRef<R>
 where
-    R: NeighborRef,
+    Ix: Indexing,
+    R: NeighborRef<Ix>,
 {
-    fn index(&self) -> VertexIndex {
+    fn index(&self) -> WeakRef<'_, Ix::VertexIndex> {
         self.0.index()
     }
 
-    fn edge(&self) -> EdgeIndex {
+    fn edge(&self) -> WeakRef<'_, Ix::EdgeIndex> {
         self.0.edge()
     }
 
-    fn src(&self) -> VertexIndex {
+    fn src(&self) -> WeakRef<'_, Ix::VertexIndex> {
         self.0.src()
     }
 
@@ -204,22 +220,23 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::index::DefaultIndexing;
     use crate::marker::{Incoming, Outgoing};
     use crate::storage::AdjList;
 
     use super::*;
 
-    fn create_graph() -> AdjList<(), i32, Directed> {
+    fn create_graph() -> AdjList<(), i32, Directed, DefaultIndexing> {
         let mut graph = AdjList::new();
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, 0);
-        graph.add_edge(v1, v2, 1);
-        graph.add_edge(v2, v0, 2);
-        graph.add_edge(v2, v1, 3);
+        graph.add_edge(&v0, &v1, 0);
+        graph.add_edge(&v1, &v2, 1);
+        graph.add_edge(&v2, &v0, 2);
+        graph.add_edge(&v2, &v1, 3);
 
         graph
     }
@@ -228,57 +245,107 @@ mod tests {
     fn endpoints() {
         let graph = Transpose::new(create_graph());
 
-        assert_eq!(graph.endpoints(1.into()), Some((2.into(), 1.into())));
-        assert_eq!(graph.endpoints(3.into()), Some((1.into(), 2.into())));
+        assert_eq!(
+            graph.endpoints(&1usize.into()),
+            Some((2usize.into(), 1usize.into()))
+        );
+        assert_eq!(
+            graph.endpoints(&3usize.into()),
+            Some((1usize.into(), 2usize.into()))
+        );
     }
 
     #[test]
     fn edge_index() {
         let graph = Transpose::new(create_graph());
 
-        assert_eq!(graph.edge_index(2.into(), 1.into()), Some(1.into()));
-        assert_eq!(graph.edge_index(1.into(), 2.into()), Some(3.into()));
+        assert_eq!(
+            graph.edge_index(&2usize.into(), &1usize.into()),
+            Some(1usize.into())
+        );
+        assert_eq!(
+            graph.edge_index(&1usize.into(), &2usize.into()),
+            Some(3usize.into())
+        );
     }
 
     #[test]
     fn edges() {
         let graph = Transpose::new(create_graph());
-        let mut edges = graph
-            .edges()
-            .map(|edge| (edge.src(), edge.dst(), *edge.data()));
+        let mut edges = graph.edges().map(|edge| {
+            (
+                *EdgeRef::<DefaultIndexing, _>::src(&edge),
+                *EdgeRef::<DefaultIndexing, _>::dst(&edge),
+                *EdgeRef::<DefaultIndexing, _>::data(&edge),
+            )
+        });
 
-        assert_eq!(edges.next(), Some((1.into(), 0.into(), 0)));
-        assert_eq!(edges.next(), Some((2.into(), 1.into(), 1)));
-        assert_eq!(edges.next(), Some((0.into(), 2.into(), 2)));
-        assert_eq!(edges.next(), Some((1.into(), 2.into(), 3)));
+        assert_eq!(edges.next(), Some((1usize.into(), 0usize.into(), 0)));
+        assert_eq!(edges.next(), Some((2usize.into(), 1usize.into(), 1)));
+        assert_eq!(edges.next(), Some((0usize.into(), 2usize.into(), 2)));
+        assert_eq!(edges.next(), Some((1usize.into(), 2usize.into(), 3)));
     }
 
     #[test]
     fn neighbors() {
         let graph = Transpose::new(create_graph());
-        let mut neighbors = graph
-            .neighbors(1.into())
-            .map(|neighbor| (neighbor.index(), neighbor.src(), neighbor.dir()));
+        let mut neighbors = graph.neighbors(&1usize.into()).map(|neighbor| {
+            (
+                NeighborRef::<DefaultIndexing>::index(&neighbor).into_owned(),
+                NeighborRef::<DefaultIndexing>::src(&neighbor).into_owned(),
+                NeighborRef::<DefaultIndexing>::dir(&neighbor),
+            )
+        });
 
-        assert_eq!(neighbors.next(), Some((2.into(), 1.into(), Incoming)));
-        assert_eq!(neighbors.next(), Some((0.into(), 1.into(), Outgoing)));
-        assert_eq!(neighbors.next(), Some((2.into(), 1.into(), Outgoing)));
+        assert_eq!(
+            neighbors.next(),
+            Some((2usize.into(), 1usize.into(), Incoming))
+        );
+        assert_eq!(
+            neighbors.next(),
+            Some((0usize.into(), 1usize.into(), Outgoing))
+        );
+        assert_eq!(
+            neighbors.next(),
+            Some((2usize.into(), 1usize.into(), Outgoing))
+        );
     }
 
     #[test]
     fn neighbors_directed() {
         let graph = Transpose::new(create_graph());
         let mut neighbors = graph
-            .neighbors_directed(1.into(), Outgoing)
-            .map(|neighbor| (neighbor.index(), neighbor.src(), neighbor.dir()));
+            .neighbors_directed(&1usize.into(), Outgoing)
+            .map(|neighbor| {
+                (
+                    NeighborRef::<DefaultIndexing>::index(&neighbor).into_owned(),
+                    NeighborRef::<DefaultIndexing>::src(&neighbor).into_owned(),
+                    NeighborRef::<DefaultIndexing>::dir(&neighbor),
+                )
+            });
 
-        assert_eq!(neighbors.next(), Some((0.into(), 1.into(), Outgoing)));
-        assert_eq!(neighbors.next(), Some((2.into(), 1.into(), Outgoing)));
+        assert_eq!(
+            neighbors.next(),
+            Some((0usize.into(), 1usize.into(), Outgoing))
+        );
+        assert_eq!(
+            neighbors.next(),
+            Some((2usize.into(), 1usize.into(), Outgoing))
+        );
 
         let mut neighbors = graph
-            .neighbors_directed(1.into(), Incoming)
-            .map(|neighbor| (neighbor.index(), neighbor.src(), neighbor.dir()));
+            .neighbors_directed(&1usize.into(), Incoming)
+            .map(|neighbor| {
+                (
+                    NeighborRef::<DefaultIndexing>::index(&neighbor).into_owned(),
+                    NeighborRef::<DefaultIndexing>::src(&neighbor).into_owned(),
+                    NeighborRef::<DefaultIndexing>::dir(&neighbor),
+                )
+            });
 
-        assert_eq!(neighbors.next(), Some((2.into(), 1.into(), Incoming)));
+        assert_eq!(
+            neighbors.next(),
+            Some((2usize.into(), 1usize.into(), Incoming))
+        );
     }
 }

--- a/src/operator/transpose.rs
+++ b/src/operator/transpose.rs
@@ -245,28 +245,16 @@ mod tests {
     fn endpoints() {
         let graph = Transpose::new(create_graph());
 
-        assert_eq!(
-            graph.endpoints(&1usize.into()),
-            Some((2usize.into(), 1usize.into()))
-        );
-        assert_eq!(
-            graph.endpoints(&3usize.into()),
-            Some((1usize.into(), 2usize.into()))
-        );
+        assert_eq!(graph.endpoints(&1.into()), Some((2.into(), 1.into())));
+        assert_eq!(graph.endpoints(&3.into()), Some((1.into(), 2.into())));
     }
 
     #[test]
     fn edge_index() {
         let graph = Transpose::new(create_graph());
 
-        assert_eq!(
-            graph.edge_index(&2usize.into(), &1usize.into()),
-            Some(1usize.into())
-        );
-        assert_eq!(
-            graph.edge_index(&1usize.into(), &2usize.into()),
-            Some(3usize.into())
-        );
+        assert_eq!(graph.edge_index(&2.into(), &1.into()), Some(1.into()));
+        assert_eq!(graph.edge_index(&1.into(), &2.into()), Some(3.into()));
     }
 
     #[test]
@@ -280,16 +268,16 @@ mod tests {
             )
         });
 
-        assert_eq!(edges.next(), Some((1usize.into(), 0usize.into(), 0)));
-        assert_eq!(edges.next(), Some((2usize.into(), 1usize.into(), 1)));
-        assert_eq!(edges.next(), Some((0usize.into(), 2usize.into(), 2)));
-        assert_eq!(edges.next(), Some((1usize.into(), 2usize.into(), 3)));
+        assert_eq!(edges.next(), Some((1.into(), 0.into(), 0)));
+        assert_eq!(edges.next(), Some((2.into(), 1.into(), 1)));
+        assert_eq!(edges.next(), Some((0.into(), 2.into(), 2)));
+        assert_eq!(edges.next(), Some((1.into(), 2.into(), 3)));
     }
 
     #[test]
     fn neighbors() {
         let graph = Transpose::new(create_graph());
-        let mut neighbors = graph.neighbors(&1usize.into()).map(|neighbor| {
+        let mut neighbors = graph.neighbors(&1.into()).map(|neighbor| {
             (
                 NeighborRef::<DefaultIndexing>::index(&neighbor).into_owned(),
                 NeighborRef::<DefaultIndexing>::src(&neighbor).into_owned(),
@@ -297,25 +285,16 @@ mod tests {
             )
         });
 
-        assert_eq!(
-            neighbors.next(),
-            Some((2usize.into(), 1usize.into(), Incoming))
-        );
-        assert_eq!(
-            neighbors.next(),
-            Some((0usize.into(), 1usize.into(), Outgoing))
-        );
-        assert_eq!(
-            neighbors.next(),
-            Some((2usize.into(), 1usize.into(), Outgoing))
-        );
+        assert_eq!(neighbors.next(), Some((2.into(), 1.into(), Incoming)));
+        assert_eq!(neighbors.next(), Some((0.into(), 1.into(), Outgoing)));
+        assert_eq!(neighbors.next(), Some((2.into(), 1.into(), Outgoing)));
     }
 
     #[test]
     fn neighbors_directed() {
         let graph = Transpose::new(create_graph());
         let mut neighbors = graph
-            .neighbors_directed(&1usize.into(), Outgoing)
+            .neighbors_directed(&1.into(), Outgoing)
             .map(|neighbor| {
                 (
                     NeighborRef::<DefaultIndexing>::index(&neighbor).into_owned(),
@@ -324,17 +303,11 @@ mod tests {
                 )
             });
 
-        assert_eq!(
-            neighbors.next(),
-            Some((0usize.into(), 1usize.into(), Outgoing))
-        );
-        assert_eq!(
-            neighbors.next(),
-            Some((2usize.into(), 1usize.into(), Outgoing))
-        );
+        assert_eq!(neighbors.next(), Some((0.into(), 1.into(), Outgoing)));
+        assert_eq!(neighbors.next(), Some((2.into(), 1.into(), Outgoing)));
 
         let mut neighbors = graph
-            .neighbors_directed(&1usize.into(), Incoming)
+            .neighbors_directed(&1.into(), Incoming)
             .map(|neighbor| {
                 (
                     NeighborRef::<DefaultIndexing>::index(&neighbor).into_owned(),
@@ -343,9 +316,6 @@ mod tests {
                 )
             });
 
-        assert_eq!(
-            neighbors.next(),
-            Some((2usize.into(), 1usize.into(), Incoming))
-        );
+        assert_eq!(neighbors.next(), Some((2.into(), 1.into(), Incoming)));
     }
 }

--- a/src/proptest.rs
+++ b/src/proptest.rs
@@ -6,6 +6,7 @@ use proptest::{
 };
 
 use crate::{
+    index::NumIndexType,
     marker::EdgeType,
     testing::{Applier, ApplyMutOps, ApplyOptions, MutOp},
     traits::Create,
@@ -18,6 +19,7 @@ where
     E: Arbitrary + Debug,
     Ty: Debug,
     G: Create<V, E, Ty> + Debug,
+    G::VertexIndex: NumIndexType,
 {
     graph_ops_strategy_with(ApplyOptions::default())
 }
@@ -30,6 +32,7 @@ where
     E: Arbitrary + Debug,
     Ty: Debug,
     G: Create<V, E, Ty> + Debug,
+    G::VertexIndex: NumIndexType,
 {
     any::<Vec<MutOp<V, E, Ty>>>().prop_map(move |ops| {
         let mut graph = G::with_capacity(ops.len(), ops.len());
@@ -45,6 +48,7 @@ where
     E: Arbitrary + Debug,
     Ty: Debug,
     G: Create<V, E, Ty> + Debug,
+    G::VertexIndex: NumIndexType,
 {
     graph_strategy_with(ApplyOptions::default())
 }
@@ -55,6 +59,7 @@ where
     E: Arbitrary + Debug,
     Ty: Debug,
     G: Create<V, E, Ty> + Debug,
+    G::VertexIndex: NumIndexType,
 {
     (any::<Vec<V>>(), any::<Vec<(usize, usize, E)>>()).prop_map(move |(vertices, edges)| {
         let vertex_count = vertices.len();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -27,14 +27,14 @@ mod tests {
         let v2 = graph.add_vertex(());
         let v3 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, ());
-        graph.add_edge(v0, v2, ());
-        let e = graph.add_edge(v0, v3, ());
-        graph.add_edge(v2, v1, ());
-        graph.add_edge(v2, v3, ());
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v0, &v2, ());
+        let e = graph.add_edge(&v0, &v3, ());
+        graph.add_edge(&v2, &v1, ());
+        graph.add_edge(&v2, &v3, ());
 
-        graph.remove_edge(e);
-        graph.remove_vertex(v1);
+        graph.remove_edge(&e);
+        graph.remove_vertex(&v1);
 
         assert_eq!(graph.vertex_count(), 3);
         assert_eq!(graph.vertex_indices().count(), graph.vertex_count());
@@ -45,24 +45,24 @@ mod tests {
         assert_eq!(graph.edges().count(), graph.edge_count());
 
         let valid_edge_indices = graph.edge_indices().all(|edge_index| {
-            let (src, dst) = graph.endpoints(edge_index).unwrap();
-            graph.edge_index(src, dst) == Some(edge_index)
+            let (src, dst) = graph.endpoints(&edge_index).unwrap();
+            graph.edge_index(&src, &dst) == Some(edge_index)
         });
         assert!(valid_edge_indices);
 
         let mut deg = graph
             .vertex_indices()
-            .map(|index| graph.degree(index))
+            .map(|index| graph.degree(&index))
             .collect::<Vec<_>>();
 
         let mut out_deg = graph
             .vertex_indices()
-            .map(|index| graph.degree_directed(index, Direction::Outgoing))
+            .map(|index| graph.degree_directed(&index, Direction::Outgoing))
             .collect::<Vec<_>>();
 
         let mut in_deg = graph
             .vertex_indices()
-            .map(|index| graph.degree_directed(index, Direction::Incoming))
+            .map(|index| graph.degree_directed(&index, Direction::Incoming))
             .collect::<Vec<_>>();
 
         deg.sort_unstable();
@@ -83,7 +83,7 @@ mod tests {
         assert_eq!(graph.edge_count(), 0);
         assert_eq!(graph.vertex_count(), 3);
 
-        graph.add_edge(v0, v1, ());
+        graph.add_edge(&v0, &v1, ());
         assert_eq!(graph.edge_count(), 1);
 
         graph.clear();
@@ -101,20 +101,20 @@ mod tests {
         let v1 = graph.add_vertex(());
         let v2 = graph.add_vertex(());
 
-        graph.add_edge(v0, v1, 0);
-        graph.add_edge(v0, v2, 1);
-        graph.add_edge(v0, v1, 2);
+        graph.add_edge(&v0, &v1, 0);
+        graph.add_edge(&v0, &v2, 1);
+        graph.add_edge(&v0, &v1, 2);
 
         let mut e01 = graph
-            .multi_edge_index(v0, v1)
-            .map(|e| graph.edge(e))
+            .multi_edge_index(&v0, &v1)
+            .map(|e| graph.edge(&e))
             .collect::<Vec<_>>();
 
         e01.sort();
 
         let e02 = graph
-            .multi_edge_index(v0, v2)
-            .map(|e| graph.edge(e))
+            .multi_edge_index(&v0, &v2)
+            .map(|e| graph.edge(&e))
             .collect::<Vec<_>>();
 
         assert_eq!(e01, vec![Some(&0), Some(&2)]);

--- a/src/storage/adj_list.rs
+++ b/src/storage/adj_list.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::marker::PhantomData;
 
 use super::shared::AdjVertex as Vertex;
@@ -9,7 +8,7 @@ use crate::marker::{Direction, EdgeType};
 use crate::traits::*;
 use crate::{EdgesBaseWeak, EdgesWeak, VerticesBaseWeak, VerticesWeak};
 
-#[derive(VerticesBaseWeak, VerticesWeak, EdgesBaseWeak, EdgesWeak, Clone, PartialEq, Eq)]
+#[derive(Debug, VerticesBaseWeak, VerticesWeak, EdgesBaseWeak, EdgesWeak, Clone, PartialEq, Eq)]
 pub struct AdjList<V, E, Ty, Ix: Indexing> {
     vertices: Vec<Vertex<Ix, V>>,
     edges: Vec<E>,
@@ -127,25 +126,6 @@ where
 impl<V, E, Ty: EdgeType, Ix: Indexing> Default for AdjList<V, E, Ty, Ix> {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl<V, E, Ty, Ix> fmt::Debug for AdjList<V, E, Ty, Ix>
-where
-    V: fmt::Debug,
-    E: fmt::Debug,
-    Ty: fmt::Debug,
-    Ix: Indexing,
-    Ix::VertexIndex: fmt::Debug,
-    Ix::EdgeIndex: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AdjList")
-            .field("vertices", &self.vertices)
-            .field("edges", &self.edges)
-            .field("endpoints", &self.endpoints)
-            .field("ty", &self.ty)
-            .finish()
     }
 }
 

--- a/src/storage/adj_matrix.rs
+++ b/src/storage/adj_matrix.rs
@@ -13,7 +13,6 @@ pub struct AdjMatrix<V, E, Ty, Ix> {
     matrix: Matrix<E, Ty, Ix>,
     vertices: Vec<V>,
     n_edges: usize,
-    ty: PhantomData<fn() -> Ix>,
 }
 
 impl<V, E, Ty: EdgeType, Ix: Indexing> AdjMatrix<V, E, Ty, Ix>
@@ -26,7 +25,6 @@ where
             matrix: Matrix::with_capacity(8),
             vertices: Vec::new(),
             n_edges: 0,
-            ty: PhantomData,
         }
     }
 }
@@ -327,7 +325,6 @@ where
             matrix: Matrix::with_capacity(vertex_count),
             vertices: Vec::with_capacity(vertex_count),
             n_edges: 0,
-            ty: PhantomData,
         }
     }
 }

--- a/src/storage/edge_list.rs
+++ b/src/storage/edge_list.rs
@@ -3,21 +3,21 @@ use std::marker::PhantomData;
 use std::slice;
 
 use super::shared::{EdgesIter, RangeIndices, VerticesIter};
-use crate::index::{EdgeIndex, IndexType, VertexIndex};
+use crate::index::{Indexing, NumIndexType};
 use crate::infra::CompactIndexMap;
 use crate::marker::{Direction, EdgeType};
 use crate::traits::*;
 use crate::{EdgesBaseWeak, EdgesWeak, VerticesBaseWeak, VerticesWeak};
 
 #[derive(Debug, VerticesBaseWeak, VerticesWeak, EdgesBaseWeak, EdgesWeak)]
-pub struct EdgeList<V, E, Ty> {
+pub struct EdgeList<V, E, Ty, Ix: Indexing> {
     vertices: Vec<V>,
     edges: Vec<E>,
-    endpoints: Vec<[VertexIndex; 2]>,
+    endpoints: Vec<[Ix::VertexIndex; 2]>,
     ty: PhantomData<Ty>,
 }
 
-impl<V, E, Ty: EdgeType> EdgeList<V, E, Ty> {
+impl<V, E, Ty: EdgeType, Ix: Indexing> EdgeList<V, E, Ty, Ix> {
     pub fn new() -> Self {
         Self {
             vertices: Vec::new(),
@@ -26,8 +26,13 @@ impl<V, E, Ty: EdgeType> EdgeList<V, E, Ty> {
             ty: PhantomData,
         }
     }
+}
 
-    fn relocate_vertex(&mut self, old_index: VertexIndex, new_index: VertexIndex) {
+impl<V, E, Ty: EdgeType, Ix: Indexing> EdgeList<V, E, Ty, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+{
+    fn relocate_vertex(&mut self, old_index: Ix::VertexIndex, new_index: Ix::VertexIndex) {
         self.endpoints.iter_mut().for_each(|endpoints| {
             for endpoint in endpoints.iter_mut() {
                 if *endpoint == old_index {
@@ -38,14 +43,22 @@ impl<V, E, Ty: EdgeType> EdgeList<V, E, Ty> {
     }
 }
 
-impl<V, E, Ty: EdgeType> Default for EdgeList<V, E, Ty> {
+impl<V, E, Ty: EdgeType, Ix: Indexing> Default for EdgeList<V, E, Ty, Ix> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<V, E, Ty: EdgeType> VerticesBase for EdgeList<V, E, Ty> {
-    type VertexIndicesIter<'a> = RangeIndices<VertexIndex>
+impl<V, E, Ty: EdgeType, Ix: Indexing> GraphBase for EdgeList<V, E, Ty, Ix> {
+    type VertexIndex = Ix::VertexIndex;
+    type EdgeIndex = Ix::EdgeIndex;
+}
+
+impl<V, E, Ty: EdgeType, Ix: Indexing> VerticesBase for EdgeList<V, E, Ty, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+{
+    type VertexIndicesIter<'a> = RangeIndices<Ix::VertexIndex>
     where
         Self: 'a;
 
@@ -61,46 +74,57 @@ impl<V, E, Ty: EdgeType> VerticesBase for EdgeList<V, E, Ty> {
         (0..self.vertex_bound()).into()
     }
 
-    fn vertex_index_map(&self) -> CompactIndexMap<VertexIndex> {
+    fn vertex_index_map(&self) -> CompactIndexMap<Ix::VertexIndex>
+    where
+        Ix::VertexIndex: NumIndexType,
+    {
         CompactIndexMap::isomorphic(self.vertex_count())
     }
 }
 
-impl<V, E, Ty: EdgeType> Vertices<V> for EdgeList<V, E, Ty> {
-    type VertexRef<'a, T: 'a> = (VertexIndex, &'a T)
+impl<V, E, Ty: EdgeType, Ix: Indexing> Vertices<V> for EdgeList<V, E, Ty, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+{
+    type VertexRef<'a> = (Ix::VertexIndex, &'a V)
     where
-        Self: 'a;
+        Self: 'a,
+        V: 'a;
 
-    type VerticesIter<'a, T: 'a> = VerticesIter<'a, T>
+    type VerticesIter<'a> = VerticesIter<'a, Ix, V>
     where
-        Self: 'a;
+        Self: 'a,
+        V: 'a;
 
-    fn vertex(&self, index: VertexIndex) -> Option<&V> {
-        self.vertices.get(index.to_usize())
+    fn vertex(&self, index: &Ix::VertexIndex) -> Option<&V> {
+        self.vertices.get(index.as_usize())
     }
 
-    fn vertices(&self) -> Self::VerticesIter<'_, V> {
+    fn vertices(&self) -> Self::VerticesIter<'_> {
         VerticesIter::new(self.vertices.iter())
     }
 }
 
-impl<V, E, Ty: EdgeType> VerticesMut<V> for EdgeList<V, E, Ty> {
-    fn vertex_mut(&mut self, index: VertexIndex) -> Option<&mut V> {
-        self.vertices.get_mut(index.to_usize())
+impl<V, E, Ty: EdgeType, Ix: Indexing> VerticesMut<V> for EdgeList<V, E, Ty, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+{
+    fn vertex_mut(&mut self, index: &Ix::VertexIndex) -> Option<&mut V> {
+        self.vertices.get_mut(index.as_usize())
     }
 
-    fn add_vertex(&mut self, vertex: V) -> VertexIndex {
+    fn add_vertex(&mut self, vertex: V) -> Ix::VertexIndex {
         let index = self.vertices.len();
         self.vertices.push(vertex);
-        index.into()
+        Ix::VertexIndex::from_usize(index)
     }
 
-    fn remove_vertex(&mut self, index: VertexIndex) -> Option<V> {
+    fn remove_vertex(&mut self, index: &Ix::VertexIndex) -> Option<V> {
         // Remove all edges connected to this vertex in any direction.
         let mut i = 0;
         while i < self.endpoints.len() {
             let endpoints = &self.endpoints[i];
-            if endpoints[0] == index || endpoints[1] == index {
+            if &endpoints[0] == index || &endpoints[1] == index {
                 self.edges.swap_remove(i);
                 self.endpoints.swap_remove(i);
             } else {
@@ -109,12 +133,12 @@ impl<V, E, Ty: EdgeType> VerticesMut<V> for EdgeList<V, E, Ty> {
         }
 
         // Remove the vertex from the graph.
-        let vertex = self.vertices.swap_remove(index.to_usize());
+        let vertex = self.vertices.swap_remove(index.as_usize());
 
         // If `swap_remove` actually moved an existing vertex somewhere, we need
         // to fix its index in the entire graph.
-        if index.to_usize() < self.vertices.len() {
-            self.relocate_vertex(self.vertices.len().into(), index);
+        if index.as_usize() < self.vertices.len() {
+            self.relocate_vertex(Ix::VertexIndex::from_usize(self.vertices.len()), *index);
         }
 
         Some(vertex)
@@ -127,8 +151,12 @@ impl<V, E, Ty: EdgeType> VerticesMut<V> for EdgeList<V, E, Ty> {
     }
 }
 
-impl<V, E, Ty: EdgeType> EdgesBase<Ty> for EdgeList<V, E, Ty> {
-    type EdgeIndicesIter<'a> = RangeIndices<EdgeIndex>
+impl<V, E, Ty: EdgeType, Ix: Indexing> EdgesBase<Ty> for EdgeList<V, E, Ty, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+    Ix::EdgeIndex: NumIndexType,
+{
+    type EdgeIndicesIter<'a> = RangeIndices<Ix::EdgeIndex>
     where
         Self: 'a;
 
@@ -140,22 +168,22 @@ impl<V, E, Ty: EdgeType> EdgesBase<Ty> for EdgeList<V, E, Ty> {
         self.edge_count()
     }
 
-    fn endpoints(&self, index: EdgeIndex) -> Option<(VertexIndex, VertexIndex)> {
+    fn endpoints(&self, index: &Ix::EdgeIndex) -> Option<(Ix::VertexIndex, Ix::VertexIndex)> {
         self.endpoints
-            .get(index.to_usize())
+            .get(index.as_usize())
             .map(|endpoints| (endpoints[0], endpoints[1]))
     }
 
-    fn edge_index(&self, src: VertexIndex, dst: VertexIndex) -> Option<EdgeIndex> {
+    fn edge_index(&self, src: &Ix::VertexIndex, dst: &Ix::VertexIndex) -> Option<Ix::EdgeIndex> {
         self.endpoints
             .iter()
             .enumerate()
             .find_map(|(i, endpoints)| {
                 #[allow(clippy::if_same_then_else)]
-                if endpoints[0] == src && endpoints[1] == dst {
-                    Some(i.into())
-                } else if !Ty::is_directed() && endpoints[1] == src && endpoints[0] == dst {
-                    Some(i.into())
+                if &endpoints[0] == src && &endpoints[1] == dst {
+                    Some(Ix::EdgeIndex::from_usize(i))
+                } else if !Ty::is_directed() && &endpoints[1] == src && &endpoints[0] == dst {
+                    Some(Ix::EdgeIndex::from_usize(i))
                 } else {
                     None
                 }
@@ -166,54 +194,67 @@ impl<V, E, Ty: EdgeType> EdgesBase<Ty> for EdgeList<V, E, Ty> {
         (0..self.edge_bound()).into()
     }
 
-    fn edge_index_map(&self) -> CompactIndexMap<EdgeIndex> {
+    fn edge_index_map(&self) -> CompactIndexMap<Ix::EdgeIndex>
+    where
+        Ix::EdgeIndex: NumIndexType,
+    {
         CompactIndexMap::isomorphic(self.edge_count())
     }
 }
 
-impl<V, E, Ty: EdgeType> Edges<E, Ty> for EdgeList<V, E, Ty> {
-    type EdgeRef<'a, T: 'a> = (EdgeIndex, &'a T, VertexIndex, VertexIndex)
+impl<V, E, Ty: EdgeType, Ix: Indexing> Edges<E, Ty> for EdgeList<V, E, Ty, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+    Ix::EdgeIndex: NumIndexType,
+{
+    type EdgeRef<'a> = (Ix::EdgeIndex, &'a E, Ix::VertexIndex, Ix::VertexIndex)
     where
-        Self: 'a;
+        Self: 'a,
+        E: 'a;
 
-    type EdgesIter<'a, T: 'a> = EdgesIter<'a, T>
+    type EdgesIter<'a> = EdgesIter<'a, Ix, E>
     where
-        Self: 'a;
+        Self: 'a,
+        E: 'a;
 
-    fn edge(&self, index: EdgeIndex) -> Option<&E> {
-        self.edges.get(index.to_usize())
+    fn edge(&self, index: &Ix::EdgeIndex) -> Option<&E> {
+        self.edges.get(index.as_usize())
     }
 
-    fn edges(&self) -> Self::EdgesIter<'_, E> {
+    fn edges(&self) -> Self::EdgesIter<'_> {
         EdgesIter::new(self.edges.iter(), self.endpoints.iter())
     }
 }
 
-impl<V, E, Ty: EdgeType> EdgesMut<E, Ty> for EdgeList<V, E, Ty> {
-    fn edge_mut(&mut self, index: EdgeIndex) -> Option<&mut E> {
-        self.edges.get_mut(index.to_usize())
+impl<V, E, Ty: EdgeType, Ix: Indexing> EdgesMut<E, Ty> for EdgeList<V, E, Ty, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+    Ix::EdgeIndex: NumIndexType,
+{
+    fn edge_mut(&mut self, index: &Ix::EdgeIndex) -> Option<&mut E> {
+        self.edges.get_mut(index.as_usize())
     }
 
-    fn add_edge(&mut self, src: VertexIndex, dst: VertexIndex, edge: E) -> EdgeIndex {
+    fn add_edge(&mut self, src: &Ix::VertexIndex, dst: &Ix::VertexIndex, edge: E) -> Ix::EdgeIndex {
         assert!(
-            src.to_usize() < self.vertices.len(),
+            src.as_usize() < self.vertices.len(),
             "src vertex does not exist"
         );
         assert!(
-            dst.to_usize() < self.vertices.len(),
+            dst.as_usize() < self.vertices.len(),
             "dst vertex does not exist"
         );
 
-        self.endpoints.push([src, dst]);
+        self.endpoints.push([*src, *dst]);
         let index = self.edges.len();
         self.edges.push(edge);
-        index.into()
+        Ix::EdgeIndex::from_usize(index)
     }
 
-    fn remove_edge(&mut self, index: EdgeIndex) -> Option<E> {
+    fn remove_edge(&mut self, index: &Ix::EdgeIndex) -> Option<E> {
         self.edge(index)?;
-        self.endpoints.swap_remove(index.to_usize());
-        Some(self.edges.swap_remove(index.to_usize()))
+        self.endpoints.swap_remove(index.as_usize());
+        Some(self.edges.swap_remove(index.as_usize()))
     }
 
     fn clear_edges(&mut self) {
@@ -222,41 +263,49 @@ impl<V, E, Ty: EdgeType> EdgesMut<E, Ty> for EdgeList<V, E, Ty> {
     }
 }
 
-impl<V, E, Ty: EdgeType> MultiEdges<E, Ty> for EdgeList<V, E, Ty> {
-    type MultiEdgeIndicesIter<'a> = MultiEdgeIndicesIter<'a, Ty>
+impl<V, E, Ty: EdgeType, Ix: Indexing> MultiEdges<E, Ty> for EdgeList<V, E, Ty, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+    Ix::EdgeIndex: NumIndexType,
+{
+    type MultiEdgeIndicesIter<'a> = MultiEdgeIndicesIter<'a, Ty, Ix>
     where
         Self: 'a;
 
     fn multi_edge_index(
         &self,
-        src: VertexIndex,
-        dst: VertexIndex,
+        src: &Ix::VertexIndex,
+        dst: &Ix::VertexIndex,
     ) -> Self::MultiEdgeIndicesIter<'_> {
         self.vertex(src).expect("vertex does not exist");
 
         MultiEdgeIndicesIter {
-            src,
-            dst,
+            src: *src,
+            dst: *dst,
             endpoints: self.endpoints.iter().enumerate(),
             ty: PhantomData,
         }
     }
 }
 
-impl<V, E, Ty: EdgeType> Neighbors for EdgeList<V, E, Ty> {
-    type NeighborRef<'a> = (VertexIndex, EdgeIndex, VertexIndex, Direction)
+impl<V, E, Ty: EdgeType, Ix: Indexing> Neighbors for EdgeList<V, E, Ty, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+    Ix::EdgeIndex: NumIndexType,
+{
+    type NeighborRef<'a> = (Ix::VertexIndex, Ix::EdgeIndex, Ix::VertexIndex, Direction)
     where
         Self: 'a;
 
-    type NeighborsIter<'a> = NeighborsIter<'a>
+    type NeighborsIter<'a> = NeighborsIter<'a, Ix>
     where
         Self: 'a;
 
-    fn neighbors(&self, src: VertexIndex) -> Self::NeighborsIter<'_> {
+    fn neighbors(&self, src: &Ix::VertexIndex) -> Self::NeighborsIter<'_> {
         self.vertex(src).expect("vertex does not exist");
 
         NeighborsIter {
-            src,
+            src: *src,
             edges: self.endpoints.as_slice(),
             dir: None,
             index: 0,
@@ -264,11 +313,11 @@ impl<V, E, Ty: EdgeType> Neighbors for EdgeList<V, E, Ty> {
         }
     }
 
-    fn neighbors_directed(&self, src: VertexIndex, dir: Direction) -> Self::NeighborsIter<'_> {
+    fn neighbors_directed(&self, src: &Ix::VertexIndex, dir: Direction) -> Self::NeighborsIter<'_> {
         self.vertex(src).expect("vertex does not exist");
 
         NeighborsIter {
-            src,
+            src: *src,
             edges: self.endpoints.as_slice(),
             dir: Some(dir),
             index: 0,
@@ -277,7 +326,11 @@ impl<V, E, Ty: EdgeType> Neighbors for EdgeList<V, E, Ty> {
     }
 }
 
-impl<V, E, Ty: EdgeType> Create<V, E, Ty> for EdgeList<V, E, Ty> {
+impl<V, E, Ty: EdgeType, Ix: Indexing> Create<V, E, Ty> for EdgeList<V, E, Ty, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+    Ix::EdgeIndex: NumIndexType,
+{
     fn with_capacity(vertex_count: usize, edge_count: usize) -> Self {
         Self {
             vertices: Vec::with_capacity(vertex_count),
@@ -288,22 +341,25 @@ impl<V, E, Ty: EdgeType> Create<V, E, Ty> for EdgeList<V, E, Ty> {
     }
 }
 
-impl<V, E, Ty: EdgeType> Guarantee for EdgeList<V, E, Ty> {}
+impl<V, E, Ty: EdgeType, Ix: Indexing> Guarantee for EdgeList<V, E, Ty, Ix> {}
 
-pub struct MultiEdgeIndicesIter<'a, Ty: EdgeType> {
-    src: VertexIndex,
-    dst: VertexIndex,
-    endpoints: Enumerate<slice::Iter<'a, [VertexIndex; 2]>>,
+pub struct MultiEdgeIndicesIter<'a, Ty: EdgeType, Ix: Indexing> {
+    src: Ix::VertexIndex,
+    dst: Ix::VertexIndex,
+    endpoints: Enumerate<slice::Iter<'a, [Ix::VertexIndex; 2]>>,
     ty: PhantomData<Ty>,
 }
 
-impl<'a, Ty: EdgeType> Iterator for MultiEdgeIndicesIter<'a, Ty> {
-    type Item = EdgeIndex;
+impl<'a, Ty: EdgeType, Ix: Indexing> Iterator for MultiEdgeIndicesIter<'a, Ty, Ix>
+where
+    Ix::EdgeIndex: NumIndexType,
+{
+    type Item = Ix::EdgeIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
         for (index, endpoints) in self.endpoints.by_ref() {
             if endpoints[0] == self.src && endpoints[1] == self.dst {
-                return Some(index.into());
+                return Some(Ix::EdgeIndex::from_usize(index));
             }
         }
 
@@ -311,23 +367,27 @@ impl<'a, Ty: EdgeType> Iterator for MultiEdgeIndicesIter<'a, Ty> {
     }
 }
 
-pub struct NeighborsIter<'a> {
-    src: VertexIndex,
-    edges: &'a [[VertexIndex; 2]],
+pub struct NeighborsIter<'a, Ix: Indexing> {
+    src: Ix::VertexIndex,
+    edges: &'a [[Ix::VertexIndex; 2]],
     index: usize,
     dir: Option<Direction>,
     is_directed: bool,
 }
 
-impl<'a> Iterator for NeighborsIter<'a> {
-    type Item = (VertexIndex, EdgeIndex, VertexIndex, Direction);
+impl<'a, Ix: Indexing> Iterator for NeighborsIter<'a, Ix>
+where
+    Ix::VertexIndex: NumIndexType,
+    Ix::EdgeIndex: NumIndexType,
+{
+    type Item = (Ix::VertexIndex, Ix::EdgeIndex, Ix::VertexIndex, Direction);
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let (endpoints, tail) = self.edges.split_first()?;
             self.edges = tail;
 
-            let index = EdgeIndex::new(self.index);
+            let index = Ix::EdgeIndex::from_usize(self.index);
             self.index += 1;
 
             let neighbor = match (self.dir, self.is_directed) {
@@ -375,26 +435,27 @@ impl<'a> Iterator for NeighborsIter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::index::DefaultIndexing;
     use crate::marker::{Directed, Undirected};
     use crate::storage::tests::*;
 
     #[test]
     fn basic_undirected() {
-        test_basic::<Undirected, EdgeList<_, _, _>>();
+        test_basic::<Undirected, EdgeList<_, _, _, DefaultIndexing>>();
     }
 
     #[test]
     fn basic_directed() {
-        test_basic::<Directed, EdgeList<_, _, _>>();
+        test_basic::<Directed, EdgeList<_, _, _, DefaultIndexing>>();
     }
 
     #[test]
     fn multi_undirected() {
-        test_multi::<Undirected, EdgeList<_, _, _>>();
+        test_multi::<Undirected, EdgeList<_, _, _, DefaultIndexing>>();
     }
 
     #[test]
     fn multi_directed() {
-        test_multi::<Directed, EdgeList<_, _, _>>();
+        test_multi::<Directed, EdgeList<_, _, _, DefaultIndexing>>();
     }
 }

--- a/src/storage/edge_list.rs
+++ b/src/storage/edge_list.rs
@@ -97,7 +97,7 @@ where
         V: 'a;
 
     fn vertex(&self, index: &Ix::VertexIndex) -> Option<&V> {
-        self.vertices.get(index.as_usize())
+        self.vertices.get(index.to_usize())
     }
 
     fn vertices(&self) -> Self::VerticesIter<'_> {
@@ -110,7 +110,7 @@ where
     Ix::VertexIndex: NumIndexType,
 {
     fn vertex_mut(&mut self, index: &Ix::VertexIndex) -> Option<&mut V> {
-        self.vertices.get_mut(index.as_usize())
+        self.vertices.get_mut(index.to_usize())
     }
 
     fn add_vertex(&mut self, vertex: V) -> Ix::VertexIndex {
@@ -133,11 +133,11 @@ where
         }
 
         // Remove the vertex from the graph.
-        let vertex = self.vertices.swap_remove(index.as_usize());
+        let vertex = self.vertices.swap_remove(index.to_usize());
 
         // If `swap_remove` actually moved an existing vertex somewhere, we need
         // to fix its index in the entire graph.
-        if index.as_usize() < self.vertices.len() {
+        if index.to_usize() < self.vertices.len() {
             self.relocate_vertex(Ix::VertexIndex::from_usize(self.vertices.len()), *index);
         }
 
@@ -170,7 +170,7 @@ where
 
     fn endpoints(&self, index: &Ix::EdgeIndex) -> Option<(Ix::VertexIndex, Ix::VertexIndex)> {
         self.endpoints
-            .get(index.as_usize())
+            .get(index.to_usize())
             .map(|endpoints| (endpoints[0], endpoints[1]))
     }
 
@@ -218,7 +218,7 @@ where
         E: 'a;
 
     fn edge(&self, index: &Ix::EdgeIndex) -> Option<&E> {
-        self.edges.get(index.as_usize())
+        self.edges.get(index.to_usize())
     }
 
     fn edges(&self) -> Self::EdgesIter<'_> {
@@ -232,16 +232,16 @@ where
     Ix::EdgeIndex: NumIndexType,
 {
     fn edge_mut(&mut self, index: &Ix::EdgeIndex) -> Option<&mut E> {
-        self.edges.get_mut(index.as_usize())
+        self.edges.get_mut(index.to_usize())
     }
 
     fn add_edge(&mut self, src: &Ix::VertexIndex, dst: &Ix::VertexIndex, edge: E) -> Ix::EdgeIndex {
         assert!(
-            src.as_usize() < self.vertices.len(),
+            src.to_usize() < self.vertices.len(),
             "src vertex does not exist"
         );
         assert!(
-            dst.as_usize() < self.vertices.len(),
+            dst.to_usize() < self.vertices.len(),
             "dst vertex does not exist"
         );
 
@@ -253,8 +253,8 @@ where
 
     fn remove_edge(&mut self, index: &Ix::EdgeIndex) -> Option<E> {
         self.edge(index)?;
-        self.endpoints.swap_remove(index.as_usize());
-        Some(self.edges.swap_remove(index.as_usize()))
+        self.endpoints.swap_remove(index.to_usize());
+        Some(self.edges.swap_remove(index.to_usize()))
     }
 
     fn clear_edges(&mut self) {

--- a/src/storage/frozen.rs
+++ b/src/storage/frozen.rs
@@ -1,16 +1,17 @@
 use std::ops::Deref;
 
-use crate::index::{EdgeIndex, VertexIndex};
+use crate::index::{EdgeIndex, NumIndexType, VertexIndex};
 use crate::infra::CompactIndexMap;
 use crate::marker::{Direction, EdgeType};
 use crate::traits::*;
 use crate::{
-    Edges, EdgesBase, EdgesBaseWeak, EdgesWeak, Guarantee, Neighbors, Vertices, VerticesBase,
-    VerticesBaseWeak, VerticesWeak,
+    Edges, EdgesBase, EdgesBaseWeak, EdgesWeak, GraphBase, Guarantee, Neighbors, Vertices,
+    VerticesBase, VerticesBaseWeak, VerticesWeak,
 };
 
 #[derive(
     Debug,
+    GraphBase,
     VerticesBase,
     Vertices,
     EdgesBase,

--- a/src/storage/shared.rs
+++ b/src/storage/shared.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::iter::{Enumerate, Zip};
 use std::marker::PhantomData;
 use std::ops::Range;
@@ -6,7 +5,7 @@ use std::slice::Iter;
 
 use crate::index::{Indexing, NumIndexType};
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdjVertex<Ix: Indexing, V> {
     pub data: V,
     pub edges: [Vec<Ix::EdgeIndex>; 2],
@@ -18,20 +17,6 @@ impl<Ix: Indexing, V> AdjVertex<Ix, V> {
             data,
             edges: [Vec::new(), Vec::new()],
         }
-    }
-}
-
-impl<Ix, V> fmt::Debug for AdjVertex<Ix, V>
-where
-    Ix: Indexing,
-    Ix::EdgeIndex: fmt::Debug,
-    V: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AdjVertex")
-            .field("data", &self.data)
-            .field("edges", &self.edges)
-            .finish()
     }
 }
 

--- a/src/storage/stable.rs
+++ b/src/storage/stable.rs
@@ -1,21 +1,23 @@
 use std::collections::BTreeSet;
-use std::marker::PhantomData;
 
-use crate::index::{EdgeIndex, VertexIndex};
+use crate::index::{EdgeIndex, NumIndexType, VertexIndex};
 use crate::infra::CompactIndexMap;
 use crate::marker::{Direction, EdgeType};
 use crate::traits::*;
-use crate::{EdgesBaseWeak, EdgesWeak, Guarantee, VerticesBaseWeak, VerticesWeak};
+use crate::{EdgesBaseWeak, EdgesWeak, GraphBase, Guarantee, VerticesBaseWeak, VerticesWeak};
 
-#[derive(Debug, VerticesBaseWeak, VerticesWeak, EdgesBaseWeak, EdgesWeak, Guarantee)]
-pub struct Stable<G> {
+#[derive(Debug, GraphBase, VerticesBaseWeak, VerticesWeak, EdgesBaseWeak, EdgesWeak, Guarantee)]
+pub struct Stable<G: GraphBase> {
     #[graph]
     inner: G,
-    removed_vertices: BTreeSet<VertexIndex>,
-    removed_edges: BTreeSet<EdgeIndex>,
+    removed_vertices: BTreeSet<G::VertexIndex>,
+    removed_edges: BTreeSet<G::EdgeIndex>,
 }
 
-impl<G> Stable<G> {
+impl<G> Stable<G>
+where
+    G: GraphBase,
+{
     pub fn new(inner: G) -> Self {
         Self {
             inner,
@@ -33,12 +35,12 @@ impl<G> Stable<G> {
         // Propagate the removals. The descending order of indices is important
         // for not invalidating the stored indices when creating "holes" in the
         // underlying graph.
-        for edge in self.removed_edges.iter().rev().copied() {
+        for edge in self.removed_edges.iter().rev() {
             let removed = inner.remove_edge(edge);
             debug_assert!(removed.is_some());
         }
 
-        for vertex in self.removed_vertices.iter().rev().copied() {
+        for vertex in self.removed_vertices.iter().rev() {
             let removed = inner.remove_vertex(vertex);
             debug_assert!(removed.is_some());
         }
@@ -50,13 +52,17 @@ impl<G> Stable<G> {
 impl<G> Default for Stable<G>
 where
     G: Default,
+    G: GraphBase,
 {
     fn default() -> Self {
         Self::new(G::default())
     }
 }
 
-impl<G> From<G> for Stable<G> {
+impl<G> From<G> for Stable<G>
+where
+    G: GraphBase,
+{
     fn from(inner: G) -> Self {
         Self::new(inner)
     }
@@ -66,7 +72,7 @@ impl<G> VerticesBase for Stable<G>
 where
     G: VerticesBase,
 {
-    type VertexIndicesIter<'a> = VertexIndices<'a, G::VertexIndicesIter<'a>>
+    type VertexIndicesIter<'a> = VertexIndices<'a, G>
     where
         Self: 'a;
 
@@ -85,15 +91,18 @@ where
         }
     }
 
-    fn contains_vertex(&self, index: VertexIndex) -> bool {
-        if self.removed_vertices.contains(&index) {
+    fn contains_vertex(&self, index: &G::VertexIndex) -> bool {
+        if self.removed_vertices.contains(index) {
             false
         } else {
             self.inner.contains_vertex(index)
         }
     }
 
-    fn vertex_index_map(&self) -> CompactIndexMap<VertexIndex> {
+    fn vertex_index_map(&self) -> CompactIndexMap<G::VertexIndex>
+    where
+        Self::VertexIndex: NumIndexType,
+    {
         if self.removed_vertices.is_empty() {
             self.inner.vertex_index_map()
         } else {
@@ -106,27 +115,28 @@ impl<V, G> Vertices<V> for Stable<G>
 where
     G: Vertices<V>,
 {
-    type VertexRef<'a, T: 'a> = G::VertexRef<'a, T>
+    type VertexRef<'a> = G::VertexRef<'a>
     where
-        Self: 'a;
+        Self: 'a,
+        V: 'a;
 
-    type VerticesIter<'a, T: 'a> = VerticesIter<'a, T, Self::VertexRef<'a, T>, G::VerticesIter<'a, T>>
+    type VerticesIter<'a> = VerticesIter<'a, V, G>
     where
-        Self: 'a;
+        Self: 'a,
+        V: 'a;
 
-    fn vertex(&self, index: VertexIndex) -> Option<&V> {
-        if self.removed_vertices.contains(&index) {
+    fn vertex(&self, index: &G::VertexIndex) -> Option<&V> {
+        if self.removed_vertices.contains(index) {
             None
         } else {
             self.inner.vertex(index)
         }
     }
 
-    fn vertices(&self) -> Self::VerticesIter<'_, V> {
+    fn vertices(&self) -> Self::VerticesIter<'_> {
         VerticesIter {
             inner: self.inner.vertices(),
             removed_vertices: &self.removed_vertices,
-            ty: PhantomData,
         }
     }
 }
@@ -136,22 +146,22 @@ where
     G: VerticesMut<V> + Neighbors,
     V: Clone,
 {
-    fn vertex_mut(&mut self, index: VertexIndex) -> Option<&mut V> {
-        if self.removed_vertices.contains(&index) {
+    fn vertex_mut(&mut self, index: &G::VertexIndex) -> Option<&mut V> {
+        if self.removed_vertices.contains(index) {
             None
         } else {
             self.inner.vertex_mut(index)
         }
     }
 
-    fn add_vertex(&mut self, vertex: V) -> VertexIndex {
+    fn add_vertex(&mut self, vertex: V) -> G::VertexIndex {
         self.inner.add_vertex(vertex)
     }
 
-    fn remove_vertex(&mut self, index: VertexIndex) -> Option<V> {
+    fn remove_vertex(&mut self, index: &G::VertexIndex) -> Option<V> {
         if let Some(data) = self.vertex(index) {
             let data = data.clone();
-            self.removed_vertices.insert(index);
+            self.removed_vertices.insert(index.clone());
 
             // Iterate over remaining neighbors only to get edges to be marked
             // as removed. An alternative could be to iterate over all neighbors
@@ -160,7 +170,7 @@ where
             // vertex has been removed.
             let mut removed_edges = BTreeSet::default();
             for neighbor in self.neighbors(index) {
-                removed_edges.insert(neighbor.edge());
+                removed_edges.insert(neighbor.edge().into_owned());
             }
 
             for edge in removed_edges {
@@ -175,11 +185,11 @@ where
 
     fn clear(&mut self) {
         for vertex in self.inner.vertex_indices() {
-            self.removed_vertices.insert(vertex);
-
-            for neighbor in self.inner.neighbors(vertex) {
-                self.removed_edges.insert(neighbor.edge());
+            for neighbor in self.inner.neighbors(&vertex) {
+                self.removed_edges.insert(neighbor.edge().into_owned());
             }
+
+            self.removed_vertices.insert(vertex);
         }
     }
 }
@@ -188,7 +198,7 @@ impl<Ty: EdgeType, G> EdgesBase<Ty> for Stable<G>
 where
     G: EdgesBase<Ty>,
 {
-    type EdgeIndicesIter<'a> = EdgeIndices<'a, G::EdgeIndicesIter<'a>>
+    type EdgeIndicesIter<'a> = EdgeIndices<'a, Ty, G>
     where
         Self: 'a;
 
@@ -200,18 +210,18 @@ where
         self.inner.edge_bound()
     }
 
-    fn endpoints(&self, index: EdgeIndex) -> Option<(VertexIndex, VertexIndex)> {
-        if self.removed_edges.contains(&index) {
+    fn endpoints(&self, index: &G::EdgeIndex) -> Option<(G::VertexIndex, G::VertexIndex)> {
+        if self.removed_edges.contains(index) {
             None
         } else {
             self.inner.endpoints(index)
         }
     }
 
-    fn edge_index(&self, src: VertexIndex, dst: VertexIndex) -> Option<EdgeIndex> {
+    fn edge_index(&self, src: &G::VertexIndex, dst: &G::VertexIndex) -> Option<G::EdgeIndex> {
         match (
-            self.removed_vertices.contains(&src),
-            self.removed_vertices.contains(&dst),
+            self.removed_vertices.contains(src),
+            self.removed_vertices.contains(dst),
         ) {
             (false, false) => self.inner.edge_index(src, dst).and_then(|index| {
                 if self.removed_edges.contains(&index) {
@@ -231,15 +241,18 @@ where
         }
     }
 
-    fn contains_edge(&self, index: EdgeIndex) -> bool {
-        if self.removed_edges.contains(&index) {
+    fn contains_edge(&self, index: &G::EdgeIndex) -> bool {
+        if self.removed_edges.contains(index) {
             false
         } else {
             self.inner.contains_edge(index)
         }
     }
 
-    fn edge_index_map(&self) -> CompactIndexMap<EdgeIndex> {
+    fn edge_index_map(&self) -> CompactIndexMap<G::EdgeIndex>
+    where
+        Self::EdgeIndex: NumIndexType,
+    {
         if self.removed_edges.is_empty() {
             self.inner.edge_index_map()
         } else {
@@ -252,27 +265,28 @@ impl<E, Ty: EdgeType, G> Edges<E, Ty> for Stable<G>
 where
     G: Edges<E, Ty>,
 {
-    type EdgeRef<'a, T: 'a> = G::EdgeRef<'a, T>
+    type EdgeRef<'a> = G::EdgeRef<'a>
     where
-        Self: 'a;
+        Self: 'a,
+        E: 'a;
 
-    type EdgesIter<'a, T: 'a> = EdgesIter<'a, T, Self::EdgeRef<'a, T>, G::EdgesIter<'a, T>>
+    type EdgesIter<'a> = EdgesIter<'a, E, Ty, G>
     where
-        Self: 'a;
+        Self: 'a,
+        E: 'a;
 
-    fn edge(&self, index: EdgeIndex) -> Option<&E> {
-        if self.removed_edges.contains(&index) {
+    fn edge(&self, index: &G::EdgeIndex) -> Option<&E> {
+        if self.removed_edges.contains(index) {
             None
         } else {
             self.inner.edge(index)
         }
     }
 
-    fn edges(&self) -> Self::EdgesIter<'_, E> {
+    fn edges(&self) -> Self::EdgesIter<'_> {
         EdgesIter {
             inner: self.inner.edges(),
             removed_edges: &self.removed_edges,
-            ty: PhantomData,
         }
     }
 }
@@ -282,22 +296,22 @@ where
     G: EdgesMut<E, Ty>,
     E: Clone,
 {
-    fn edge_mut(&mut self, index: EdgeIndex) -> Option<&mut E> {
-        if self.removed_edges.contains(&index) {
+    fn edge_mut(&mut self, index: &G::EdgeIndex) -> Option<&mut E> {
+        if self.removed_edges.contains(index) {
             None
         } else {
             self.inner.edge_mut(index)
         }
     }
 
-    fn add_edge(&mut self, src: VertexIndex, dst: VertexIndex, edge: E) -> EdgeIndex {
+    fn add_edge(&mut self, src: &G::VertexIndex, dst: &G::VertexIndex, edge: E) -> G::EdgeIndex {
         self.inner.add_edge(src, dst, edge)
     }
 
-    fn remove_edge(&mut self, index: EdgeIndex) -> Option<E> {
+    fn remove_edge(&mut self, index: &G::EdgeIndex) -> Option<E> {
         if let Some(data) = self.edge(index) {
             let data = data.clone();
-            self.removed_edges.insert(index);
+            self.removed_edges.insert(index.clone());
             Some(data)
         } else {
             None
@@ -323,7 +337,7 @@ where
     where
         Self: 'a;
 
-    fn neighbors(&self, src: VertexIndex) -> Self::NeighborsIter<'_> {
+    fn neighbors(&self, src: &G::VertexIndex) -> Self::NeighborsIter<'_> {
         NeighborsIter {
             inner: self.inner.neighbors(src),
             removed_vertices: &self.removed_vertices,
@@ -331,7 +345,7 @@ where
         }
     }
 
-    fn neighbors_directed(&self, src: VertexIndex, dir: Direction) -> Self::NeighborsIter<'_> {
+    fn neighbors_directed(&self, src: &G::VertexIndex, dir: Direction) -> Self::NeighborsIter<'_> {
         NeighborsIter {
             inner: self.inner.neighbors_directed(src, dir),
             removed_vertices: &self.removed_vertices,
@@ -349,135 +363,99 @@ where
     }
 }
 
-impl<G> StableIndices<VertexIndex, NoReplace> for Stable<G> {}
-impl<G> StableIndices<EdgeIndex, NoReplace> for Stable<G> {}
+impl<G: GraphBase> StableIndices<VertexIndex, NoReplace> for Stable<G> {}
+impl<G: GraphBase> StableIndices<EdgeIndex, NoReplace> for Stable<G> {}
 
 pub trait Stabilize {
     fn stabilize(self) -> Stable<Self>
     where
-        Self: Sized;
+        Self: Sized + GraphBase;
 }
 
-pub struct VertexIndices<'a, I> {
-    inner: I,
-    removed_vertices: &'a BTreeSet<VertexIndex>,
+pub struct VertexIndices<'a, G: VerticesBase + 'a> {
+    inner: G::VertexIndicesIter<'a>,
+    removed_vertices: &'a BTreeSet<G::VertexIndex>,
 }
 
-impl<'a, I> Iterator for VertexIndices<'a, I>
-where
-    I: Iterator<Item = VertexIndex>,
-{
-    type Item = VertexIndex;
+impl<'a, G: VerticesBase> Iterator for VertexIndices<'a, G> {
+    type Item = G::VertexIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for index in self.inner.by_ref() {
-            if !self.removed_vertices.contains(&index) {
-                return Some(index);
-            }
-        }
-
-        None
+        self.inner
+            .by_ref()
+            .find(|index| !self.removed_vertices.contains(index))
     }
 }
 
-pub struct VerticesIter<'a, V: 'a, R, I> {
-    inner: I,
-    removed_vertices: &'a BTreeSet<VertexIndex>,
-    ty: PhantomData<(V, R)>,
+pub struct VerticesIter<'a, V: 'a, G: Vertices<V> + 'a> {
+    inner: G::VerticesIter<'a>,
+    removed_vertices: &'a BTreeSet<G::VertexIndex>,
 }
 
-impl<'a, V: 'a, R, I> Iterator for VerticesIter<'a, V, R, I>
-where
-    R: VertexRef<V>,
-    I: Iterator<Item = R>,
-{
-    type Item = R;
+impl<'a, V, G: Vertices<V>> Iterator for VerticesIter<'a, V, G> {
+    type Item = G::VertexRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for vertex in self.inner.by_ref() {
-            if !self.removed_vertices.contains(&vertex.index()) {
-                return Some(vertex);
-            }
-        }
-
-        None
+        self.inner
+            .by_ref()
+            .find(|vertex| !self.removed_vertices.contains(vertex.index()))
     }
 }
 
-pub struct EdgeIndices<'a, I> {
-    inner: I,
-    removed_edges: &'a BTreeSet<EdgeIndex>,
+pub struct EdgeIndices<'a, Ty: EdgeType, G: EdgesBase<Ty> + 'a> {
+    inner: G::EdgeIndicesIter<'a>,
+    removed_edges: &'a BTreeSet<G::EdgeIndex>,
 }
 
-impl<'a, I> Iterator for EdgeIndices<'a, I>
-where
-    I: Iterator<Item = EdgeIndex>,
-{
-    type Item = EdgeIndex;
+impl<'a, Ty: EdgeType, G: EdgesBase<Ty>> Iterator for EdgeIndices<'a, Ty, G> {
+    type Item = G::EdgeIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for index in self.inner.by_ref() {
-            if !self.removed_edges.contains(&index) {
-                return Some(index);
-            }
-        }
-
-        None
+        self.inner
+            .by_ref()
+            .find(|index| !self.removed_edges.contains(index))
     }
 }
 
-pub struct EdgesIter<'a, E: 'a, R: EdgeRef<E>, I> {
-    inner: I,
-    removed_edges: &'a BTreeSet<EdgeIndex>,
-    ty: PhantomData<(E, R)>,
+pub struct EdgesIter<'a, E: 'a, Ty: EdgeType, G: Edges<E, Ty> + 'a> {
+    inner: G::EdgesIter<'a>,
+    removed_edges: &'a BTreeSet<G::EdgeIndex>,
 }
 
-impl<'a, E: 'a, R, I> Iterator for EdgesIter<'a, E, R, I>
-where
-    R: EdgeRef<E>,
-    I: Iterator<Item = R>,
-{
-    type Item = R;
+impl<'a, E, Ty: EdgeType, G: Edges<E, Ty>> Iterator for EdgesIter<'a, E, Ty, G> {
+    type Item = G::EdgeRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for edge in self.inner.by_ref() {
-            if !self.removed_edges.contains(&edge.index()) {
-                return Some(edge);
-            }
-        }
-
-        None
+        self.inner
+            .by_ref()
+            .find(|edge| !self.removed_edges.contains(edge.index()))
     }
 }
 
-pub struct NeighborsIter<'a, S: Neighbors + 'a> {
-    inner: S::NeighborsIter<'a>,
-    removed_vertices: &'a BTreeSet<VertexIndex>,
-    removed_edges: &'a BTreeSet<EdgeIndex>,
+pub struct NeighborsIter<'a, G: Neighbors + 'a> {
+    inner: G::NeighborsIter<'a>,
+    removed_vertices: &'a BTreeSet<G::VertexIndex>,
+    removed_edges: &'a BTreeSet<G::EdgeIndex>,
 }
 
-impl<'a, S> Iterator for NeighborsIter<'a, S>
+impl<'a, G> Iterator for NeighborsIter<'a, G>
 where
-    S: Neighbors,
+    G: Neighbors,
 {
-    type Item = S::NeighborRef<'a>;
+    type Item = G::NeighborRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for neighbor in self.inner.by_ref() {
-            if !self.removed_edges.contains(&neighbor.edge())
+        self.inner.by_ref().find(|neighbor| {
+            !self.removed_edges.contains(&neighbor.edge())
                 && !self.removed_vertices.contains(&neighbor.index())
-            {
-                return Some(neighbor);
-            }
-        }
-
-        None
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::index::DefaultIndexing;
     use crate::marker::{Directed, Undirected};
     use crate::storage::tests::*;
     use crate::storage::AdjList;
@@ -486,17 +464,18 @@ mod tests {
 
     #[test]
     fn basic_undirected() {
-        test_basic::<Undirected, Stable<AdjList<_, _, _>>>();
+        test_basic::<Undirected, Stable<AdjList<_, _, _, DefaultIndexing>>>();
     }
 
     #[test]
     fn basic_directed() {
-        test_basic::<Directed, Stable<AdjList<_, _, _>>>();
+        test_basic::<Directed, Stable<AdjList<_, _, _, DefaultIndexing>>>();
     }
 
     #[test]
     fn apply() {
-        let mut graph: Stable<AdjList<_, _, Undirected>> = Stable::new(AdjList::new());
+        let mut graph: Stable<AdjList<_, _, Undirected, DefaultIndexing>> =
+            Stable::new(AdjList::new());
 
         let u = graph.add_vertex("u");
         let v = graph.add_vertex("v");
@@ -505,18 +484,18 @@ mod tests {
         let y = graph.add_vertex("y");
         let z = graph.add_vertex("z");
 
-        let e = graph.add_edge(u, v, "e");
-        graph.add_edge(w, x, "f");
-        let g = graph.add_edge(y, z, "g");
+        let e = graph.add_edge(&u, &v, "e");
+        graph.add_edge(&w, &x, "f");
+        let g = graph.add_edge(&y, &z, "g");
 
         // Testing if the apply operation successfully removes all vertices and
         // edges, even if the underlying graph does not have stable indices.
 
-        graph.remove_edge(e);
-        graph.remove_edge(g);
+        graph.remove_edge(&e);
+        graph.remove_edge(&g);
 
-        graph.remove_vertex(u);
-        graph.remove_vertex(z);
+        graph.remove_vertex(&u);
+        graph.remove_vertex(&z);
 
         let graph = graph.apply();
 
@@ -525,7 +504,7 @@ mod tests {
 
         let vertices = graph
             .vertices()
-            .map(|v| v.data().to_string())
+            .map(|v| VertexRef::<DefaultIndexing, _>::data(&v).to_string())
             .collect::<HashSet<_>>();
 
         assert!(vertices.contains("v"));
@@ -535,7 +514,7 @@ mod tests {
 
         let edges = graph
             .edges()
-            .map(|e| e.data().to_string())
+            .map(|e| EdgeRef::<DefaultIndexing, _>::data(&e).to_string())
             .collect::<HashSet<_>>();
 
         assert!(edges.contains("f"));
@@ -543,60 +522,65 @@ mod tests {
 
     #[test]
     fn contains_vertex() {
-        let mut graph: Stable<AdjList<_, (), Undirected>> = Stable::new(AdjList::new());
+        let mut graph: Stable<AdjList<_, (), Undirected, DefaultIndexing>> =
+            Stable::new(AdjList::new());
 
         let v = graph.add_vertex(());
-        graph.remove_vertex(v);
+        graph.remove_vertex(&v);
 
-        assert!(!graph.contains_vertex(v));
+        assert!(!graph.contains_vertex(&v));
     }
 
     #[test]
     fn contains_edge() {
-        let mut graph: Stable<AdjList<_, _, Undirected>> = Stable::new(AdjList::new());
+        let mut graph: Stable<AdjList<_, _, Undirected, DefaultIndexing>> =
+            Stable::new(AdjList::new());
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
-        let e = graph.add_edge(v0, v1, ());
+        let e = graph.add_edge(&v0, &v1, ());
 
-        graph.remove_edge(e);
+        graph.remove_edge(&e);
 
-        assert!(!graph.contains_edge(e));
+        assert!(!graph.contains_edge(&e));
     }
 
     #[test]
     fn edge_index() {
-        let mut graph: Stable<AdjList<_, _, Undirected>> = Stable::new(AdjList::new());
+        let mut graph: Stable<AdjList<_, _, Undirected, DefaultIndexing>> =
+            Stable::new(AdjList::new());
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
-        let e = graph.add_edge(v0, v1, ());
+        let e = graph.add_edge(&v0, &v1, ());
 
-        graph.remove_edge(e);
+        graph.remove_edge(&e);
 
-        assert!(graph.edge_index(v0, v1).is_none());
+        assert!(graph.edge_index(&v0, &v1).is_none());
     }
 
     #[test]
     #[should_panic]
     fn replace_vertex() {
-        let mut graph: Stable<AdjList<_, (), Undirected>> = Stable::new(AdjList::new());
+        let mut graph: Stable<AdjList<_, (), Undirected, DefaultIndexing>> =
+            Stable::new(AdjList::new());
 
         let v = graph.add_vertex(());
-        graph.remove_vertex(v);
-        graph.replace_vertex(v, ());
+        graph.remove_vertex(&v);
+        graph.replace_vertex(&v, ());
     }
 
     #[test]
     #[should_panic]
     fn replace_edge() {
-        let mut graph: Stable<AdjList<_, _, Undirected>> = Stable::new(AdjList::new());
+        let mut graph: Stable<AdjList<_, _, Undirected, DefaultIndexing>> =
+            Stable::new(AdjList::new());
 
         let v0 = graph.add_vertex(());
         let v1 = graph.add_vertex(());
-        let e = graph.add_edge(v0, v1, ());
+        let e = graph.add_edge(&v0, &v1, ());
 
-        graph.remove_edge(e);
-        graph.replace_edge(e, ());
+        graph.remove_edge(&e);
+        graph.replace_edge(&e, ());
     }
 }

--- a/src/storage/stable.rs
+++ b/src/storage/stable.rs
@@ -504,7 +504,7 @@ mod tests {
 
         let vertices = graph
             .vertices()
-            .map(|v| VertexRef::<DefaultIndexing, _>::data(&v).to_string())
+            .map(|v| v.data().to_string())
             .collect::<HashSet<_>>();
 
         assert!(vertices.contains("v"));
@@ -514,7 +514,7 @@ mod tests {
 
         let edges = graph
             .edges()
-            .map(|e| EdgeRef::<DefaultIndexing, _>::data(&e).to_string())
+            .map(|e| e.data().to_string())
             .collect::<HashSet<_>>();
 
         assert!(edges.contains("f"));

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -13,12 +13,12 @@ where
         facts::complete_graph_edge_count::<Ty>(vertex_count),
     );
 
-    for _ in 0..vertex_count {
-        graph.add_vertex(V::default());
-    }
+    let vertices = (0..vertex_count)
+        .map(|_| graph.add_vertex(V::default()))
+        .collect::<Vec<_>>();
 
-    for u in 0..vertex_count {
-        for v in 0..vertex_count {
+    for u in vertices.clone() {
+        for v in vertices.clone() {
             if u == v {
                 continue;
             }
@@ -27,7 +27,7 @@ where
                 break;
             }
 
-            graph.add_edge(u.into(), v.into(), E::default());
+            graph.add_edge(&u, &v, E::default());
         }
     }
 
@@ -42,23 +42,27 @@ pub fn create_bipartite<V, E, Ty: EdgeType, G, F>(
 where
     V: Default,
     G: Create<V, E, Ty>,
-    F: Fn(usize, usize, Direction) -> Option<E>,
+    F: Fn(&G::VertexIndex, &G::VertexIndex, Direction) -> Option<E>,
 {
     let vertex_count = vertex_count_lhs + vertex_count_rhs;
 
     let mut graph = G::with_capacity(vertex_count, vertex_count);
 
-    for _ in 0..vertex_count {
-        graph.add_vertex(V::default());
-    }
+    let vertices_lhs = (0..vertex_count_lhs)
+        .map(|_| graph.add_vertex(V::default()))
+        .collect::<Vec<_>>();
+
+    let vertices_rhs = (0..vertex_count_rhs)
+        .map(|_| graph.add_vertex(V::default()))
+        .collect::<Vec<_>>();
 
     for dir in Ty::directions() {
-        for i in 0..vertex_count_lhs {
-            for j in 0..vertex_count_rhs {
-                if let Some(edge) = connect(i, j, *dir) {
+        for i in vertices_lhs.clone() {
+            for j in vertices_rhs.clone() {
+                if let Some(edge) = connect(&i, &j, *dir) {
                     match dir {
-                        Direction::Outgoing => graph.add_edge(i.into(), j.into(), edge),
-                        Direction::Incoming => graph.add_edge(j.into(), i.into(), edge),
+                        Direction::Outgoing => graph.add_edge(&i, &j, edge),
+                        Direction::Incoming => graph.add_edge(&j, &i, edge),
                     };
                 }
             }
@@ -79,11 +83,12 @@ where
     }
 
     let mut graph = G::with_capacity(vertex_count, vertex_count - 1);
-    graph.add_vertex(V::default());
+    let mut src = graph.add_vertex(V::default());
 
-    for i in 1..vertex_count {
+    for _ in 1..vertex_count {
         let dst = graph.add_vertex(V::default());
-        graph.add_edge((i - 1).into(), dst, E::default());
+        graph.add_edge(&src, &dst, E::default());
+        src = dst;
     }
 
     graph
@@ -99,14 +104,13 @@ mod random {
     use std::marker::PhantomData;
 
     use crate::export::{Dot, Export};
-    use crate::index::{EdgeIndex, VertexIndex};
+    use crate::index::NumIndexType;
     use crate::infra::CompactIndexMap;
     use crate::marker::{Direction, EdgeType};
     use crate::traits::*;
-    use crate::IndexType;
     use crate::{
-        Edges, EdgesBase, EdgesBaseWeak, EdgesWeak, Guarantee, Neighbors, Vertices, VerticesBase,
-        VerticesBaseWeak, VerticesWeak,
+        Edges, EdgesBase, EdgesBaseWeak, EdgesWeak, GraphBase, Guarantee, Neighbors, Vertices,
+        VerticesBase, VerticesBaseWeak, VerticesWeak,
     };
 
     #[cfg(feature = "proptest")]
@@ -220,6 +224,7 @@ mod random {
     impl<V, E, Ty: EdgeType, G> ApplyMutOps<V, E, Ty> for Applier<'_, G>
     where
         G: VerticesMut<V> + EdgesMut<E, Ty>,
+        G::VertexIndex: NumIndexType,
     {
         fn apply_one(&mut self, op: MutOp<V, E, Ty>) {
             match op {
@@ -234,7 +239,7 @@ mod random {
                     if self.graph.vertex_count() > 0 {
                         let map = self.graph.vertex_index_map();
                         let index = map.real(index % self.graph.vertex_count()).unwrap();
-                        self.graph.remove_vertex(index);
+                        self.graph.remove_vertex(&index);
                     }
                 }
                 MutOp::AddEdge(src, dst, edge, _) => {
@@ -247,11 +252,12 @@ mod random {
                             return;
                         }
 
-                        if !self.options.multi_edges && self.graph.edge_index(src, dst).is_some() {
+                        if !self.options.multi_edges && self.graph.edge_index(&src, &dst).is_some()
+                        {
                             return;
                         }
 
-                        self.graph.add_edge(src, dst, edge);
+                        self.graph.add_edge(&src, &dst, edge);
                     }
                 }
                 MutOp::RemoveEdge(src, dst) => {
@@ -263,8 +269,8 @@ mod random {
                         let map = self.graph.vertex_index_map();
                         let src = map.real(src % self.graph.vertex_count()).unwrap();
                         let dst = map.real(dst % self.graph.vertex_count()).unwrap();
-                        if let Some(index) = self.graph.edge_index(src, dst) {
-                            self.graph.remove_edge(index);
+                        if let Some(index) = self.graph.edge_index(&src, &dst) {
+                            self.graph.remove_edge(&index);
                         }
                     }
                 }
@@ -273,6 +279,7 @@ mod random {
     }
 
     #[derive(
+        GraphBase,
         VerticesBase,
         Vertices,
         EdgesBase,
@@ -321,6 +328,7 @@ mod random {
         V: Clone + fmt::Debug,
         E: Clone + fmt::Debug,
         G: Create<V, E, Ty>,
+        G::VertexIndex: NumIndexType,
     {
         fn with_capacity(vertex_count: usize, edge_count: usize) -> Self {
             Self::new(G::with_capacity(vertex_count, edge_count))
@@ -331,22 +339,23 @@ mod random {
     where
         V: Clone,
         G: VerticesMut<V>,
+        G::VertexIndex: NumIndexType,
     {
-        fn vertex_mut(&mut self, index: VertexIndex) -> Option<&mut V> {
+        fn vertex_mut(&mut self, index: &Self::VertexIndex) -> Option<&mut V> {
             self.graph.vertex_mut(index)
         }
 
-        fn add_vertex(&mut self, vertex: V) -> VertexIndex {
+        fn add_vertex(&mut self, vertex: V) -> Self::VertexIndex {
             self.history.push(MutOp::AddVertex(vertex.clone()));
             self.graph.add_vertex(vertex)
         }
 
-        fn remove_vertex(&mut self, index: VertexIndex) -> Option<V> {
-            self.history.push(MutOp::RemoveVertex(index.to_usize()));
+        fn remove_vertex(&mut self, index: &Self::VertexIndex) -> Option<V> {
+            self.history.push(MutOp::RemoveVertex(index.as_usize()));
             self.graph.remove_vertex(index)
         }
 
-        fn replace_vertex(&mut self, index: VertexIndex, vertex: V) -> V {
+        fn replace_vertex(&mut self, index: &Self::VertexIndex, vertex: V) -> V {
             self.graph.replace_vertex(index, vertex)
         }
     }
@@ -355,30 +364,36 @@ mod random {
     where
         E: Clone,
         G: EdgesMut<E, Ty>,
+        G::VertexIndex: NumIndexType,
     {
-        fn edge_mut(&mut self, index: EdgeIndex) -> Option<&mut E> {
+        fn edge_mut(&mut self, index: &Self::EdgeIndex) -> Option<&mut E> {
             self.graph.edge_mut(index)
         }
 
-        fn add_edge(&mut self, src: VertexIndex, dst: VertexIndex, edge: E) -> EdgeIndex {
+        fn add_edge(
+            &mut self,
+            src: &Self::VertexIndex,
+            dst: &Self::VertexIndex,
+            edge: E,
+        ) -> Self::EdgeIndex {
             self.history.push(MutOp::AddEdge(
-                src.to_usize(),
-                dst.to_usize(),
+                src.as_usize(),
+                dst.as_usize(),
                 edge.clone(),
                 PhantomData,
             ));
             self.graph.add_edge(src, dst, edge)
         }
 
-        fn remove_edge(&mut self, index: EdgeIndex) -> Option<E> {
+        fn remove_edge(&mut self, index: &Self::EdgeIndex) -> Option<E> {
             if let Some((src, dst)) = self.endpoints(index) {
                 self.history
-                    .push(MutOp::RemoveEdge(src.to_usize(), dst.to_usize()));
+                    .push(MutOp::RemoveEdge(src.as_usize(), dst.as_usize()));
             }
             self.graph.remove_edge(index)
         }
 
-        fn replace_edge(&mut self, index: EdgeIndex, edge: E) -> E {
+        fn replace_edge(&mut self, index: &Self::EdgeIndex, edge: E) -> E {
             self.graph.replace_edge(index, edge)
         }
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -351,7 +351,7 @@ mod random {
         }
 
         fn remove_vertex(&mut self, index: &Self::VertexIndex) -> Option<V> {
-            self.history.push(MutOp::RemoveVertex(index.as_usize()));
+            self.history.push(MutOp::RemoveVertex(index.to_usize()));
             self.graph.remove_vertex(index)
         }
 
@@ -377,8 +377,8 @@ mod random {
             edge: E,
         ) -> Self::EdgeIndex {
             self.history.push(MutOp::AddEdge(
-                src.as_usize(),
-                dst.as_usize(),
+                src.to_usize(),
+                dst.to_usize(),
                 edge.clone(),
                 PhantomData,
             ));
@@ -388,7 +388,7 @@ mod random {
         fn remove_edge(&mut self, index: &Self::EdgeIndex) -> Option<E> {
             if let Some((src, dst)) = self.endpoints(index) {
                 self.history
-                    .push(MutOp::RemoveEdge(src.as_usize(), dst.as_usize()));
+                    .push(MutOp::RemoveEdge(src.to_usize(), dst.to_usize()));
             }
             self.graph.remove_edge(index)
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -395,7 +395,7 @@ where
     {
         for edge in iter {
             let (src, dst, edge) = edge.unpack();
-            let vertex_bound = max(src, dst).as_usize();
+            let vertex_bound = max(src, dst).to_usize();
 
             while self.vertex_count() <= vertex_bound {
                 self.add_vertex(V::default());

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -140,6 +140,8 @@ where
     type EdgeIndex = G::EdgeIndex;
 }
 
+type GraphIndexing<G> = CustomIndexing<<G as GraphBase>::VertexIndex, <G as GraphBase>::EdgeIndex>;
+
 pub trait VerticesBase: GraphBase {
     type VertexIndicesIter<'a>: Iterator<Item = Self::VertexIndex>
     where
@@ -163,7 +165,7 @@ pub trait VerticesBase: GraphBase {
 }
 
 pub trait Vertices<V>: VerticesBase {
-    type VertexRef<'a>: VertexRef<CustomIndexing<Self::VertexIndex, Self::EdgeIndex>, V>
+    type VertexRef<'a>: VertexRef<GraphIndexing<Self>, V>
     where
         Self: 'a,
         V: 'a;
@@ -241,7 +243,7 @@ pub trait EdgesBase<Ty: EdgeType>: GraphBase {
 }
 
 pub trait Edges<E, Ty: EdgeType>: EdgesBase<Ty> {
-    type EdgeRef<'a>: EdgeRef<CustomIndexing<Self::VertexIndex, Self::EdgeIndex>, E>
+    type EdgeRef<'a>: EdgeRef<GraphIndexing<Self>, E>
     where
         Self: 'a,
         E: 'a;
@@ -324,7 +326,7 @@ pub trait NeighborRef<Ix: Indexing + ?Sized> {
 }
 
 pub trait Neighbors: GraphBase {
-    type NeighborRef<'a>: NeighborRef<CustomIndexing<Self::VertexIndex, Self::EdgeIndex>>
+    type NeighborRef<'a>: NeighborRef<GraphIndexing<Self>>
     where
         Self: 'a;
 

--- a/src/visit/raw.rs
+++ b/src/visit/raw.rs
@@ -6,11 +6,11 @@ use std::{
 
 use rustc_hash::FxHashSet;
 
-use crate::{index::Indexing, infra::VisitSet};
-use crate::{index::UseIndex, traits::*};
 use crate::{
-    index::{IndexType, UseVertexIndex},
+    index::{IndexType, Indexing, UseIndex, UseVertexIndex},
+    infra::VisitSet,
     marker::Outgoing,
+    traits::*,
 };
 
 pub trait TraversalCollection<T>: Default {


### PR DESCRIPTION
This is a version of generic index types that compiles, but it has still many rough edges. A few examples:

- ~`CustomIndexing` trick in traits.rs, which is needed for `impl ... for &G`, because using just `Self` causes an (understandable) compilation error. If there is no other way, it should at least get a better name (`DelegateIndexing`?) and be private?~
- ~In many cases there is a "VertexRef::data type annotations needed" (`VertexRef::data` is just one example) error. This is very unergonomic and a solution must be found. This arises from the fact that plain tuples do not hold information about `Ix: Indexing`.~
- ~During the implementation, clones were deliberately added anywhere where needed to make code compile. They should be reviewed if some of them can be removed by changing an API (e.g., take something by reference)~ Checked all new clones and I didn't find any good opportunity to avoid a clone (it is either so cheap that it is not worthy to complicate the API or is in testing code).
- `UseIndex` trait in `visit::raw` is quite an overkill. Maybe it's a necessary implementation detail (we need `Ix: Indexing` to avoid "Ix is not constrained by trait, Self type, ..." error), but it should not be visible outside of `visit::raw`.
- ~Conversions from/to usize for `NumIndexType` are cumbersome right now as explicit `NumIndexType::from_usize` must be used instead of simple `.into()`. This should be improved as well.~
- ~Use [Borrow](https://doc.rust-lang.org/nightly/std/borrow/trait.Borrow.html) trait for index arguments, so that both owned indexes and references to indexes can be used in API such as `vertex(...)` and `add_edge(...)`. This will help ergonomics and aesthetics on the user side in majority of cases, when default index types are used as they are `Copy`.~
- ~Make `IndexType: Debug`~

Following commits should resolve mentioned problems and polish the code in general.