### PR TITLE
Beginning the correctness journey

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,9 @@ jobs:
       fail-fast: false
       matrix:
         rust: [stable, beta, nightly]
+    env:
+      # Property-based tests are ignored if not compiled with this --cfg.
+      RUSTFLAGS: --cfg proptest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,23 +5,22 @@ authors = ["Petr Nevyhoštěný"]
 edition = "2021"
 
 [dependencies]
-fixedbitset = "0.4"
-bitvec = "1"
-rustc-hash = "1"
+fixedbitset = "0.4.2"
+bitvec = "1.0.1"
+rustc-hash = "1.1.0"
 
 macros = { path = "macros" }
 
-arbitrary = { version = "1.0", features = ["derive"], optional = true }
-proptest = { version = "1.0", optional = true }
-# https://github.com/AltSysrq/proptest/pull/260
-proptest-derive = { git = "https://github.com/pnevyk/proptest", branch = "fix-derive-type-use-tracking-order", optional = true }
+arbitrary = { version = "1.2.3", features = ["derive"], optional = true }
+proptest = { version = "1.1.0", optional = true }
 thiserror = "1.0.38"
 
 [dev-dependencies]
 # Remove once https://github.com/rust-lang/rust/issues/82775 is stabilized
 assert_matches = "1.5.0"
+fastrand = "1.9.0"
 
 [features]
 default = ["arbitrary", "proptest"]
 arbitrary = ["dep:arbitrary"]
-proptest = ["dep:proptest", "dep:proptest-derive"]
+proptest = ["dep:proptest"]

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "gryf-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.gryf]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "adj_list_undirected"
+path = "fuzz_targets/adj_list_undirected.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "adj_list_directed"
+path = "fuzz_targets/adj_list_directed.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "adj_matrix_undirected"
+path = "fuzz_targets/adj_matrix_undirected.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "adj_matrix_directed"
+path = "fuzz_targets/adj_matrix_directed.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "edge_list_undirected"
+path = "fuzz_targets/edge_list_undirected.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "edge_list_directed"
+path = "fuzz_targets/edge_list_directed.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/adj_list_directed.rs
+++ b/fuzz/fuzz_targets/adj_list_directed.rs
@@ -1,0 +1,21 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use gryf::{
+    core::{index::DefaultIndexing, marker::Directed},
+    infra::{arbitrary::MutOpsSeq, testing::check_consistency},
+    storage::AdjList,
+};
+
+fuzz_target!(|ops: MutOpsSeq<i8, i8>| {
+    let mut graph = AdjList::<_, _, Directed, DefaultIndexing>::new();
+
+    for op in ops {
+        op.apply(&mut graph);
+        check_consistency(&graph)
+            .as_ref()
+            .map_err(ToString::to_string)
+            .unwrap();
+    }
+});

--- a/fuzz/fuzz_targets/adj_list_undirected.rs
+++ b/fuzz/fuzz_targets/adj_list_undirected.rs
@@ -1,0 +1,21 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use gryf::{
+    core::{index::DefaultIndexing, marker::Undirected},
+    infra::{arbitrary::MutOpsSeq, testing::check_consistency},
+    storage::AdjList,
+};
+
+fuzz_target!(|ops: MutOpsSeq<i8, i8>| {
+    let mut graph = AdjList::<_, _, Undirected, DefaultIndexing>::new();
+
+    for op in ops {
+        op.apply(&mut graph);
+        check_consistency(&graph)
+            .as_ref()
+            .map_err(ToString::to_string)
+            .unwrap();
+    }
+});

--- a/fuzz/fuzz_targets/adj_matrix_directed.rs
+++ b/fuzz/fuzz_targets/adj_matrix_directed.rs
@@ -1,0 +1,21 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use gryf::{
+    core::{index::DefaultIndexing, marker::Directed},
+    infra::{arbitrary::MutOpsSeq, testing::check_consistency},
+    storage::AdjMatrix,
+};
+
+fuzz_target!(|ops: MutOpsSeq<i8, i8>| {
+    let mut graph = AdjMatrix::<_, _, Directed, DefaultIndexing>::new();
+
+    for op in ops {
+        op.apply(&mut graph);
+        check_consistency(&graph)
+            .as_ref()
+            .map_err(ToString::to_string)
+            .unwrap();
+    }
+});

--- a/fuzz/fuzz_targets/adj_matrix_undirected.rs
+++ b/fuzz/fuzz_targets/adj_matrix_undirected.rs
@@ -1,0 +1,21 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use gryf::{
+    core::{index::DefaultIndexing, marker::Undirected},
+    infra::{arbitrary::MutOpsSeq, testing::check_consistency},
+    storage::AdjMatrix,
+};
+
+fuzz_target!(|ops: MutOpsSeq<i8, i8>| {
+    let mut graph = AdjMatrix::<_, _, Undirected, DefaultIndexing>::new();
+
+    for op in ops {
+        op.apply(&mut graph);
+        check_consistency(&graph)
+            .as_ref()
+            .map_err(ToString::to_string)
+            .unwrap();
+    }
+});

--- a/fuzz/fuzz_targets/edge_list_directed.rs
+++ b/fuzz/fuzz_targets/edge_list_directed.rs
@@ -1,0 +1,21 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use gryf::{
+    core::{index::DefaultIndexing, marker::Directed},
+    infra::{arbitrary::MutOpsSeq, testing::check_consistency},
+    storage::EdgeList,
+};
+
+fuzz_target!(|ops: MutOpsSeq<i8, i8>| {
+    let mut graph = EdgeList::<_, _, Directed, DefaultIndexing>::new();
+
+    for op in ops {
+        op.apply(&mut graph);
+        check_consistency(&graph)
+            .as_ref()
+            .map_err(ToString::to_string)
+            .unwrap();
+    }
+});

--- a/fuzz/fuzz_targets/edge_list_undirected.rs
+++ b/fuzz/fuzz_targets/edge_list_undirected.rs
@@ -1,0 +1,21 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use gryf::{
+    core::{index::DefaultIndexing, marker::Undirected},
+    infra::{arbitrary::MutOpsSeq, testing::check_consistency},
+    storage::EdgeList,
+};
+
+fuzz_target!(|ops: MutOpsSeq<i8, i8>| {
+    let mut graph = EdgeList::<_, _, Undirected, DefaultIndexing>::new();
+
+    for op in ops {
+        op.apply(&mut graph);
+        check_consistency(&graph)
+            .as_ref()
+            .map_err(ToString::to_string)
+            .unwrap();
+    }
+});

--- a/src/core/edges.rs
+++ b/src/core/edges.rs
@@ -64,7 +64,7 @@ pub trait Edges<E, Ty: EdgeType>: EdgesBase<Ty> {
     fn edges(&self) -> Self::EdgesIter<'_>;
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 #[error("adding edge failed: {kind}")]
 pub struct AddEdgeError<E> {
     pub data: E,

--- a/src/core/edges.rs
+++ b/src/core/edges.rs
@@ -125,6 +125,15 @@ pub trait EdgesMut<E, Ty: EdgeType>: Edges<E, Ty> {
         }
     }
 
+    fn remove_edge_between(
+        &mut self,
+        src: &Self::VertexIndex,
+        dst: &Self::VertexIndex,
+    ) -> Option<E> {
+        let index = self.edge_index(src, dst)?;
+        self.remove_edge(&index)
+    }
+
     fn try_replace_edge(
         &mut self,
         index: &Self::EdgeIndex,

--- a/src/core/vertices.rs
+++ b/src/core/vertices.rs
@@ -51,7 +51,7 @@ pub trait Vertices<V>: VerticesBase {
     fn vertices(&self) -> Self::VerticesIter<'_>;
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 #[error("adding vertex failed: {kind}")]
 pub struct AddVertexError<V> {
     pub data: V,

--- a/src/graph/generic.rs
+++ b/src/graph/generic.rs
@@ -333,6 +333,14 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.remove_edge(index.borrow())
     }
 
+    pub fn remove_edge_between<VI>(&mut self, src: VI, dst: VI) -> Option<E>
+    where
+        G: EdgesMut<E, Ty>,
+        VI: Borrow<G::VertexIndex>,
+    {
+        self.graph.remove_edge_between(src.borrow(), dst.borrow())
+    }
+
     pub fn replace_edge<EI>(&mut self, index: EI, edge: E) -> E
     where
         G: EdgesMut<E, Ty>,

--- a/src/graph/generic.rs
+++ b/src/graph/generic.rs
@@ -251,12 +251,20 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         self.graph.endpoints(index.borrow())
     }
 
-    pub fn edge_index<VI>(&self, src: VI, dst: VI) -> Option<G::EdgeIndex>
+    pub fn edge_index<VI>(&self, src: VI, dst: VI) -> G::EdgeIndexIter<'_>
     where
         G: EdgesBase<Ty>,
         VI: Borrow<G::VertexIndex>,
     {
         self.graph.edge_index(src.borrow(), dst.borrow())
+    }
+
+    pub fn edge_index_any<VI>(&self, src: VI, dst: VI) -> Option<G::EdgeIndex>
+    where
+        G: EdgesBase<Ty>,
+        VI: Borrow<G::VertexIndex>,
+    {
+        self.graph.edge_index_any(src.borrow(), dst.borrow())
     }
 
     pub fn edge_indices(&self) -> G::EdgeIndicesIter<'_>
@@ -362,14 +370,6 @@ impl<V, E, Ty: EdgeType, G> Graph<V, E, Ty, G> {
         G: EdgesMut<E, Ty>,
     {
         self.graph.clear_edges()
-    }
-
-    pub fn multi_edge_index<VI>(&self, src: VI, dst: VI) -> G::MultiEdgeIndicesIter<'_>
-    where
-        G: MultiEdges<E, Ty>,
-        VI: Borrow<G::VertexIndex>,
-    {
-        self.graph.multi_edge_index(src.borrow(), dst.borrow())
     }
 
     pub fn neighbors<VI>(&self, src: VI) -> G::NeighborsIter<'_>

--- a/src/graph/generic.rs
+++ b/src/graph/generic.rs
@@ -33,6 +33,7 @@ use crate::core::{
 
 #[derive(
     Debug,
+    Clone,
     GraphBase,
     VerticesBase,
     Vertices,
@@ -48,7 +49,7 @@ use crate::core::{
     EdgesWeak,
     Guarantee,
 )]
-pub struct Graph<V, E, Ty: EdgeType, G> {
+pub struct Graph<V, E, Ty: EdgeType, G = AdjList<V, E, Ty, DefaultIndexing>> {
     #[graph]
     graph: G,
     ty: PhantomData<(V, E, Ty)>,

--- a/src/graph/path.rs
+++ b/src/graph/path.rs
@@ -487,12 +487,20 @@ where
         self.graph.endpoints(index.borrow())
     }
 
-    pub fn edge_index<VI>(&self, src: VI, dst: VI) -> Option<G::EdgeIndex>
+    pub fn edge_index<VI>(&self, src: VI, dst: VI) -> G::EdgeIndexIter<'_>
     where
         G: EdgesBase<Ty>,
         VI: Borrow<G::VertexIndex>,
     {
         self.graph.edge_index(src.borrow(), dst.borrow())
+    }
+
+    pub fn edge_index_any<VI>(&self, src: VI, dst: VI) -> Option<G::EdgeIndex>
+    where
+        G: EdgesBase<Ty>,
+        VI: Borrow<G::VertexIndex>,
+    {
+        self.graph.edge_index_any(src.borrow(), dst.borrow())
     }
 
     pub fn edge_indices(&self) -> G::EdgeIndicesIter<'_>
@@ -992,7 +1000,7 @@ mod tests {
         let v = result.unwrap();
         assert_eq!(path.ends(), Some(&[v0, v]));
 
-        assert!(path.edge_index(&v0, &v).is_some());
+        assert!(path.edge_index_any(&v0, &v).is_some());
     }
 
     #[test]
@@ -1014,6 +1022,6 @@ mod tests {
         let v = result.unwrap();
         assert_eq!(path.ends(), Some(&[v0, v]));
 
-        assert!(path.edge_index(&v1, &v).is_some());
+        assert!(path.edge_index_any(&v1, &v).is_some());
     }
 }

--- a/src/graph/path.rs
+++ b/src/graph/path.rs
@@ -30,6 +30,7 @@ use super::generic::Graph;
 
 #[derive(
     Debug,
+    Clone,
     GraphBase,
     VerticesBase,
     Vertices,
@@ -41,7 +42,7 @@ use super::generic::Graph;
     EdgesBaseWeak,
     EdgesWeak,
 )]
-pub struct Path<V, E, Ty: EdgeType, G>
+pub struct Path<V, E, Ty: EdgeType, G = AdjList<V, E, Ty, DefaultIndexing>>
 where
     G: GraphBase,
 {

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -1,8 +1,11 @@
 pub mod export;
 pub mod testing;
 
+#[cfg(feature = "proptest")]
+pub mod proptest;
+
 #[cfg(feature = "arbitrary")]
 pub mod arbitrary;
 
-#[cfg(feature = "proptest")]
-pub mod proptest;
+#[cfg(feature = "arbitrary")]
+pub mod modeling;

--- a/src/infra/arbitrary.rs
+++ b/src/infra/arbitrary.rs
@@ -1,124 +1,479 @@
-use std::{fmt, marker::PhantomData};
+use std::fmt;
 
 use arbitrary::{Arbitrary, Unstructured};
 
-use crate::core::{index::NumIndexType, marker::EdgeType, EdgesMut, VerticesMut};
-
-use super::testing::{Applier, ApplyMutOps, MutOp};
-
-use crate::derive::{
-    Edges, EdgesBase, EdgesBaseWeak, EdgesMut, EdgesWeak, GraphBase, Guarantee, Neighbors,
-    Vertices, VerticesBase, VerticesBaseWeak, VerticesMut, VerticesWeak,
-};
-
-// TODO: Remove these imports once hygiene of procedural macros is fixed.
-use crate::common::CompactIndexMap;
 use crate::core::{
-    marker::Direction, AddEdgeError, AddVertexError, Edges, EdgesBase, EdgesBaseWeak, EdgesWeak,
-    GraphBase, Guarantee, Neighbors, Vertices, VerticesBase, VerticesBaseWeak, VerticesWeak,
-    WeakRef,
+    index::{IndexType, Indexing, NumIndexType},
+    marker::EdgeType,
+    AddEdgeError, AddVertexError, EdgesBase, EdgesMut, VerticesBase, VerticesMut,
 };
 
-#[derive(
-    GraphBase,
-    VerticesBase,
-    Vertices,
-    VerticesMut,
-    EdgesBase,
-    Edges,
-    EdgesMut,
-    Neighbors,
-    VerticesBaseWeak,
-    VerticesWeak,
-    EdgesBaseWeak,
-    EdgesWeak,
-    Guarantee,
-)]
-pub struct ArbitraryGraph<V, E, Ty: EdgeType, G> {
-    #[graph]
-    graph: G,
-    ty: PhantomData<(V, E, Ty)>,
-}
+#[derive(Debug, Arbitrary, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Index(pub usize);
 
-impl<V, E, Ty: EdgeType, G> fmt::Debug for ArbitraryGraph<V, E, Ty, G>
-where
-    G: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.graph)
+impl Index {
+    pub fn get(&self, m: usize) -> Option<usize> {
+        if m > 0 {
+            Some(self.0 % m)
+        } else {
+            None
+        }
+    }
+
+    pub fn map(self, m: usize) -> Option<Index> {
+        self.get(m).map(Index)
     }
 }
 
-impl<'a, V, E, Ty: EdgeType, G> Arbitrary<'a> for ArbitraryGraph<V, E, Ty, G>
+#[derive(Debug, Arbitrary, Clone)]
+pub enum MutOp<V, E> {
+    AddVertex(V),
+    RemoveVertex(Index),
+    Clear,
+    AddEdge(Index, Index, E),
+    RemoveEdge(Index, Index),
+    ClearEdges,
+}
+
+#[derive(Debug)]
+pub enum MutOpResult<V, E, VI, EI> {
+    AddVertex(Result<VI, AddVertexError<V>>),
+    RemoveVertex(Option<V>),
+    Clear,
+    AddEdge(Result<EI, AddEdgeError<E>>),
+    RemoveEdge(Option<E>),
+    ClearEdges,
+}
+
+impl<V, E, VI1, EI1, VI2, EI2> PartialEq<MutOpResult<V, E, VI2, EI2>>
+    for MutOpResult<V, E, VI1, EI1>
+where
+    V: PartialEq,
+    E: PartialEq,
+    VI1: PartialEq<VI2>,
+    EI1: PartialEq<EI2>,
+{
+    fn eq(&self, other: &MutOpResult<V, E, VI2, EI2>) -> bool {
+        self == other
+    }
+}
+
+impl<V, E> MutOp<V, E> {
+    pub fn apply<Ty, G>(self, graph: &mut G) -> MutOpResult<V, E, G::VertexIndex, G::EdgeIndex>
+    where
+        Ty: EdgeType,
+        G: VerticesMut<V> + EdgesMut<E, Ty>,
+        G::VertexIndex: NumIndexType,
+        G::EdgeIndex: NumIndexType,
+    {
+        let n = graph.vertex_bound();
+
+        match self {
+            MutOp::AddVertex(vertex) => MutOpResult::AddVertex(graph.try_add_vertex(vertex)),
+            MutOp::RemoveVertex(index) => {
+                let index = G::VertexIndex::from_usize(index.get(n).unwrap_or_default());
+                MutOpResult::RemoveVertex(graph.remove_vertex(&index))
+            }
+            MutOp::Clear => {
+                graph.clear();
+                MutOpResult::Clear
+            }
+            MutOp::AddEdge(src, dst, edge) => {
+                let src = G::VertexIndex::from_usize(src.get(n).unwrap_or_default());
+                let dst = G::VertexIndex::from_usize(dst.get(n).unwrap_or_default());
+                MutOpResult::AddEdge(graph.try_add_edge(&src, &dst, edge))
+            }
+            MutOp::RemoveEdge(src, dst) => {
+                let src = G::VertexIndex::from_usize(src.get(n).unwrap_or_default());
+                let dst = G::VertexIndex::from_usize(dst.get(n).unwrap_or_default());
+                let index = match graph.edge_index_any(&src, &dst) {
+                    Some(index) => index,
+                    None => return MutOpResult::RemoveEdge(None),
+                };
+                MutOpResult::RemoveEdge(graph.remove_edge(&index))
+            }
+            MutOp::ClearEdges => {
+                graph.clear_edges();
+                MutOpResult::ClearEdges
+            }
+        }
+    }
+}
+
+pub struct MutOpsSeq<V, E>(pub Vec<MutOp<V, E>>);
+
+impl<V, E> IntoIterator for MutOpsSeq<V, E> {
+    type Item = MutOp<V, E>;
+    type IntoIter = std::vec::IntoIter<MutOp<V, E>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<V, E> MutOpsSeq<V, E> {
+    pub fn replay<Ty, G>(self, graph: &mut G)
+    where
+        V: fmt::Debug,
+        E: fmt::Debug,
+        Ty: EdgeType,
+        G: VerticesMut<V> + EdgesMut<E, Ty>,
+        G::VertexIndex: NumIndexType,
+        G::EdgeIndex: NumIndexType,
+    {
+        println!("let mut graph; // graph storage with ArbitraryIndexing");
+        println!();
+
+        for op in self {
+            let n = graph.vertex_bound();
+
+            let op = match op {
+                MutOp::RemoveVertex(index) => MutOp::RemoveVertex(index.map(n).unwrap_or_default()),
+                MutOp::AddEdge(src, dst, edge) => MutOp::AddEdge(
+                    src.map(n).unwrap_or_default(),
+                    dst.map(n).unwrap_or_default(),
+                    edge,
+                ),
+                MutOp::RemoveEdge(src, dst) => MutOp::RemoveEdge(
+                    src.map(n).unwrap_or_default(),
+                    dst.map(n).unwrap_or_default(),
+                ),
+                op => op,
+            };
+
+            match &op {
+                MutOp::AddVertex(vertex) => println!("graph.add_vertex({vertex:?});"),
+                MutOp::RemoveVertex(index) => println!("graph.remove_vertex(&{index:?});"),
+                MutOp::Clear => println!("graph.clear();"),
+                MutOp::AddEdge(src, dst, edge) => {
+                    println!("graph.add_edge(&{src:?}, &{dst:?}, {edge:?});")
+                }
+                MutOp::RemoveEdge(src, dst) => {
+                    println!("graph.remove_edge_between(&{src:?}, &{dst:?});")
+                }
+                MutOp::ClearEdges => println!("graph.clear_edges();"),
+            }
+
+            op.apply(graph);
+        }
+
+        println!();
+        println!("check_consistency(&graph);");
+    }
+}
+
+impl<V: fmt::Debug, E: fmt::Debug> fmt::Debug for MutOpsSeq<V, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "MutOpsSeq(vec![")?;
+
+        for op in self.0.iter() {
+            writeln!(f, "    MutOp::{:?},", op)?;
+        }
+
+        writeln!(f, "])")?;
+        writeln!(f, ".replay(&mut graph);")?;
+        writeln!(f)?;
+        writeln!(f, "// use `cargo test fuzz_replay_mut_ops_seq`")
+    }
+}
+
+impl IndexType for Index {}
+
+impl From<usize> for Index {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Index> for usize {
+    fn from(value: Index) -> Self {
+        value.0
+    }
+}
+
+impl NumIndexType for Index {
+    fn to_bits(self) -> u64 {
+        self.0 as u64
+    }
+
+    fn from_bits(bits: u64) -> Self {
+        Self(bits as usize)
+    }
+
+    fn null() -> Self {
+        Self(usize::MAX)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ArbitraryIndexing {}
+
+impl Indexing for ArbitraryIndexing {
+    type VertexIndex = Index;
+    type EdgeIndex = Index;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum OpKind {
+    AddVertex,
+    AddEdge,
+    RemoveVertex,
+    RemoveEdge,
+    Clear,
+    ClearEdges,
+}
+
+impl<'a, V, E> Arbitrary<'a> for MutOpsSeq<V, E>
 where
     V: Arbitrary<'a>,
     E: Arbitrary<'a>,
-    G: Default + VerticesMut<V> + EdgesMut<E, Ty>,
-    G::VertexIndex: NumIndexType,
 {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let mut graph = G::default();
-        let mut applier = Applier::new(&mut graph);
+        let n_target = u.int_in_range(10..=1000)?;
+        let r = u.nice_f64()?;
 
-        let _: Result<(), arbitrary::Error> = (|| {
-            loop {
-                // Choose a kind of operation with different weights.
-                let kind = u.choose(&[
-                    OpKind::Vertex,
-                    OpKind::Vertex,
-                    OpKind::Edge,
-                    OpKind::Edge,
-                    OpKind::Edge,
-                    OpKind::Edge,
-                    OpKind::Edge,
-                ])?;
+        let m_target = ((n_target * (n_target - 1) / 2) as f64 * r).round() as usize;
 
-                let op = match kind {
-                    OpKind::Vertex => MutOp::AddVertex(V::arbitrary(u)?),
-                    OpKind::Edge => MutOp::AddEdge(
-                        usize::arbitrary(u)?,
-                        usize::arbitrary(u)?,
-                        E::arbitrary(u)?,
-                        PhantomData,
-                    ),
-                };
+        let total = u.len();
 
-                applier.apply_one(op);
+        let mut n = 0usize;
+        let mut m = 0usize;
+        let mut seq = Vec::with_capacity(n_target);
+
+        while !u.is_empty() {
+            let rv = (n as f64 / n_target as f64).min(1.0);
+            let re = (m as f64 / m_target as f64).min(1.0);
+            let r = (total - u.len()) as f64 / total as f64;
+
+            let op = match arbitrary_op(u, rv, re, r) {
+                Ok(op) => op,
+                Err(_) => break,
+            };
+
+            match op {
+                MutOp::AddVertex(_) => n += 1,
+                MutOp::RemoveVertex(_) => n = n.saturating_sub(1),
+                MutOp::Clear => {
+                    n = 0;
+                    m = 0
+                }
+                MutOp::AddEdge(_, _, _) => m += 1,
+                MutOp::RemoveEdge(_, _) => m = m.saturating_sub(1),
+                MutOp::ClearEdges => m = 0,
             }
-        })();
 
-        Ok(Self {
-            graph,
-            ty: PhantomData,
-        })
+            seq.push(op);
+        }
+
+        Ok(MutOpsSeq(seq))
     }
 }
 
-#[derive(Arbitrary)]
-enum OpKind {
-    Vertex,
-    Edge,
+fn arbitrary_op<'a, V, E>(
+    u: &mut Unstructured<'a>,
+    rv: f64,
+    re: f64,
+    r: f64,
+) -> arbitrary::Result<MutOp<V, E>>
+where
+    V: Arbitrary<'a>,
+    E: Arbitrary<'a>,
+{
+    // The more vertices/edges are in the graph, the less is needed to add them.
+    // The ratio of added vertices/edges is artificially biased to be larger by
+    // averaging with progress ratio. The weights of the average are chosen such
+    // that the progress ratio less influences the edges so that we keep adding
+    // edges during the process.
+    let wv = non_linear_decrease(0.4 * rv + 0.6 * r);
+    let we = non_linear_decrease(0.6 * re + 0.4 * r);
+
+    u.choose_weighted(
+        &[
+            OpKind::AddVertex,
+            OpKind::AddEdge,
+            OpKind::RemoveVertex,
+            OpKind::RemoveEdge,
+            OpKind::Clear,
+            OpKind::ClearEdges,
+        ],
+        // Removal weights are opposite to the adding weights, scaled down a
+        // little bit (to prefer adding compared to removing). Clearing should
+        // be rare operation.
+        &[wv, we, (1.0 - wv) * 0.25, (1.0 - we) * 0.5, 0.01, 0.01],
+    )
+    .and_then(|kind| match kind {
+        OpKind::AddVertex => Ok(MutOp::AddVertex(u.arbitrary()?)),
+        OpKind::AddEdge => Ok(MutOp::AddEdge(
+            u.arbitrary()?,
+            u.arbitrary()?,
+            u.arbitrary()?,
+        )),
+        OpKind::RemoveVertex => Ok(MutOp::RemoveVertex(u.arbitrary()?)),
+        OpKind::RemoveEdge => Ok(MutOp::RemoveEdge(u.arbitrary()?, u.arbitrary()?)),
+        OpKind::Clear => Ok(MutOp::Clear),
+        OpKind::ClearEdges => Ok(MutOp::ClearEdges),
+    })
 }
 
-impl<V, E, Ty: EdgeType, G> ArbitraryGraph<V, E, Ty, G> {
-    pub fn into_inner(self) -> G {
-        self.graph
+trait UnstructuredExt {
+    fn nice_f64(&mut self) -> arbitrary::Result<f64>;
+    fn choose_weighted<'b, T>(
+        &mut self,
+        choices: &'b [T],
+        weights: &'b [f64],
+    ) -> arbitrary::Result<&'b T>;
+}
+
+impl<'a> UnstructuredExt for Unstructured<'a> {
+    fn nice_f64(&mut self) -> arbitrary::Result<f64> {
+        const RESOLUTION: u8 = 100;
+        let int = self.int_in_range(0..=RESOLUTION)?;
+        Ok(int as f64 / RESOLUTION as f64)
     }
+
+    fn choose_weighted<'b, T>(
+        &mut self,
+        choices: &'b [T],
+        weights: &'b [f64],
+    ) -> arbitrary::Result<&'b T> {
+        if choices.is_empty() || choices.len() != weights.len() {
+            return Err(arbitrary::Error::EmptyChoose);
+        }
+
+        let weight_sum = weights.iter().copied().sum::<f64>();
+
+        let random = self.nice_f64()?;
+        let bound = random * weight_sum;
+
+        let mut acc = 0.0;
+        for (choice, weight) in choices.iter().zip(weights.iter().copied()) {
+            acc += weight;
+
+            if acc >= bound {
+                return Ok(choice);
+            }
+        }
+
+        unreachable!();
+    }
+}
+
+// f(0) = 1, f(1) ~= 0.152
+fn non_linear_decrease(x: f64) -> f64 {
+    1.0 / (x + 1.0).powf(std::f64::consts::E)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use fastrand::Rng;
+
     use super::*;
 
-    use crate::{
-        core::{index::DefaultIndexing, marker::Undirected},
-        storage::AdjList,
-    };
+    #[test]
+    fn mut_ops_seq_arbitrary_sanity() {
+        let mut frequency = HashMap::<_, usize>::new();
+        let mut position = HashMap::<_, Vec<f64>>::new();
+
+        let mut total = 0;
+
+        // Try to collect operations frequency and position at which they occur
+        // in the sequence from a few runs.
+        for size in [500, 1000, 5000, 10000] {
+            let mut raw = vec![0; size];
+
+            for seed in [0, 3, 7, 13, 23, 42, 69, 123, 666, 1024] {
+                let rng = Rng::with_seed(seed);
+                rng.fill(&mut raw);
+
+                let mut u = Unstructured::new(&raw);
+                let seq: MutOpsSeq<i8, i8> = u.arbitrary().unwrap();
+
+                let count = seq.0.len();
+                total += count;
+
+                for (i, op) in seq.into_iter().enumerate() {
+                    let kind = match op {
+                        MutOp::AddVertex(_) => OpKind::AddVertex,
+                        MutOp::RemoveVertex(_) => OpKind::RemoveVertex,
+                        MutOp::Clear => OpKind::Clear,
+                        MutOp::AddEdge(_, _, _) => OpKind::AddEdge,
+                        MutOp::RemoveEdge(_, _) => OpKind::RemoveEdge,
+                        MutOp::ClearEdges => OpKind::ClearEdges,
+                    };
+
+                    *frequency.entry(kind).or_default() += 1;
+                    position
+                        .entry(kind)
+                        .or_default()
+                        .push(i as f64 / count as f64);
+                }
+            }
+        }
+
+        let frequency = frequency
+            .into_iter()
+            .map(|(key, value)| (key, value as f64 / total as f64))
+            .collect::<HashMap<_, _>>();
+        let position = position
+            .into_iter()
+            .map(|(key, values)| {
+                let count = values.len();
+                let average = values.into_iter().sum::<f64>() / count as f64;
+                (key, average)
+            })
+            .collect::<HashMap<_, _>>();
+
+        macro_rules! assert_range {
+            ($range:expr, $map:expr, $kind:expr) => {
+                let value = $map.get(&$kind).copied().unwrap_or_default();
+                assert!(
+                    ($range).contains(&value),
+                    "{} of {:?} ({} not in {:?})",
+                    stringify!($map),
+                    $kind,
+                    value,
+                    $range,
+                );
+            };
+        }
+
+        assert_range!(0.25..=0.5, frequency, OpKind::AddVertex);
+        assert_range!(0.4..=0.75, frequency, OpKind::AddEdge);
+        assert_range!(0.05..=0.2, frequency, OpKind::RemoveVertex);
+        assert_range!(0.05..=0.2, frequency, OpKind::RemoveEdge);
+        assert_range!(0.005..=0.01, frequency, OpKind::Clear);
+        assert_range!(0.005..=0.01, frequency, OpKind::ClearEdges);
+
+        // Addition operations should lean towards the beginning of the process.
+        // Removal operation should lean towards the end.
+        assert_range!(0.2..=0.5, position, OpKind::AddVertex);
+        assert_range!(0.2..=0.6, position, OpKind::AddEdge);
+        assert_range!(0.5..=0.8, position, OpKind::RemoveVertex);
+        assert_range!(0.4..=0.8, position, OpKind::RemoveEdge);
+    }
 
     #[test]
-    fn is_arbitrary() {
-        fn assert_arbitrary<'a, T: Arbitrary<'a>>() {}
+    #[ignore = "placeholder for fuzz findings"]
+    fn fuzz_replay_mut_ops_seq() {
+        #[allow(unused_imports)]
+        use crate::{
+            core::marker::{Directed, Undirected},
+            storage::*,
+        };
 
-        assert_arbitrary::<ArbitraryGraph<(), (), Undirected, AdjList<_, _, _, DefaultIndexing>>>();
+        // Replace wit graph type under test.
+        let mut graph = AdjList::<_, _, Undirected, ArbitraryIndexing>::new();
+
+        MutOpsSeq(vec![
+            MutOp::AddVertex(0),
+            MutOp::AddEdge(Index(0), Index(0), 0),
+            MutOp::ClearEdges,
+            MutOp::RemoveEdge(Index(0), Index(0)),
+        ])
+        .replay(&mut graph);
+
+        panic!("check_consistency is required for reproduction");
     }
 }

--- a/src/infra/export.rs
+++ b/src/infra/export.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fmt::Display,
-    io::{self, Write},
+    io::{self, Cursor, Write},
     marker::PhantomData,
 };
 
@@ -30,6 +30,17 @@ impl<V, E, Ty: EdgeType> Dot<V, E, Ty> {
             get_edge_label: Box::new(get_edge_label),
             ty: PhantomData,
         }
+    }
+
+    pub fn to_string<G>(&self, graph: &G) -> String
+    where
+        G: Vertices<V> + Edges<E, Ty>,
+    {
+        let mut cursor = Cursor::new(Vec::new());
+        self.export(graph, &mut cursor)
+            .expect("writing to vec in cursor does not fail");
+
+        String::from_utf8(cursor.into_inner()).expect("dot format is text format")
     }
 }
 

--- a/src/infra/modeling.rs
+++ b/src/infra/modeling.rs
@@ -1,0 +1,670 @@
+use std::marker::PhantomData;
+
+use arbitrary::Arbitrary;
+
+use crate::core::{
+    index::{EdgeIndex, NumIndexType, VertexIndex},
+    marker::{Direction, EdgeType},
+    AddEdgeError, AddEdgeErrorKind, AddVertexError, Edges, EdgesBase, EdgesMut, GraphBase,
+    Neighbors, Vertices, VerticesBase, VerticesMut,
+};
+
+use super::arbitrary::MutOp;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Arbitrary)]
+pub enum RemovalBehavior {
+    SwapRemove,
+    TombStone,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Arbitrary)]
+pub struct ModelParams {
+    allow_multi_edges: bool,
+    allow_loops: bool,
+    max_vertex_count: Option<usize>,
+    max_edge_count: Option<usize>,
+    max_remove_vertices: Option<usize>,
+    max_remove_edges: Option<usize>,
+    removal_behavior: RemovalBehavior,
+}
+
+impl Default for ModelParams {
+    fn default() -> Self {
+        Self {
+            allow_multi_edges: false,
+            allow_loops: false,
+            max_vertex_count: None,
+            max_edge_count: None,
+            max_remove_vertices: None,
+            max_remove_edges: None,
+            removal_behavior: RemovalBehavior::SwapRemove,
+        }
+    }
+}
+
+impl ModelParams {
+    pub fn allow_multi_edges(self) -> Self {
+        Self {
+            allow_multi_edges: true,
+            ..self
+        }
+    }
+
+    pub fn allow_loops(self) -> Self {
+        Self {
+            allow_loops: true,
+            ..self
+        }
+    }
+
+    pub fn max_vertex_count(self, value: usize) -> Self {
+        Self {
+            max_vertex_count: Some(value),
+            ..self
+        }
+    }
+
+    pub fn max_edge_count(self, value: usize) -> Self {
+        Self {
+            max_edge_count: Some(value),
+            ..self
+        }
+    }
+
+    pub fn max_remove_vertices(self, value: usize) -> Self {
+        Self {
+            max_remove_vertices: Some(value),
+            ..self
+        }
+    }
+
+    pub fn no_remove_vertices(self) -> Self {
+        Self {
+            max_remove_vertices: Some(0),
+            ..self
+        }
+    }
+
+    pub fn max_remove_edges(self, value: usize) -> Self {
+        Self {
+            max_remove_edges: Some(value),
+            ..self
+        }
+    }
+
+    pub fn no_remove_edges(self) -> Self {
+        Self {
+            max_remove_edges: Some(0),
+            ..self
+        }
+    }
+
+    pub fn no_remove(self) -> Self {
+        self.no_remove_vertices().no_remove_edges()
+    }
+
+    pub fn swap_remove(self) -> Self {
+        self.removal_behavior(RemovalBehavior::SwapRemove)
+    }
+
+    pub fn tomb_stone(self) -> Self {
+        self.removal_behavior(RemovalBehavior::TombStone)
+    }
+
+    pub fn removal_behavior(self, value: RemovalBehavior) -> Self {
+        Self {
+            removal_behavior: value,
+            ..self
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Model<V, E, Ty> {
+    vertices: Vec<Option<V>>,
+    edges: Vec<Option<E>>,
+    neighbors: Vec<Option<(usize, usize)>>,
+    removed_vertices: usize,
+    removed_edges: usize,
+    ty: PhantomData<Ty>,
+    params: ModelParams,
+}
+
+impl<V, E, Ty: EdgeType> Model<V, E, Ty> {
+    pub fn new(params: ModelParams) -> Self {
+        Self {
+            vertices: Vec::new(),
+            edges: Vec::new(),
+            neighbors: Vec::new(),
+            removed_vertices: 0,
+            removed_edges: 0,
+            ty: PhantomData,
+            params,
+        }
+    }
+
+    pub fn check(&self, op: &MutOp<V, E>) -> bool {
+        match op {
+            MutOp::RemoveVertex(_)
+                if self.params.max_remove_vertices == Some(self.removed_vertices) =>
+            {
+                return false
+            }
+            MutOp::RemoveEdge(_, _) if self.params.max_remove_edges == Some(self.removed_edges) => {
+                return false
+            }
+            _ => {}
+        }
+
+        match op {
+            MutOp::AddEdge(src, dst, _) if !self.params.allow_loops && src == dst => return false,
+            _ => {}
+        }
+
+        if !self.params.allow_multi_edges {
+            if let MutOp::AddEdge(src, dst, _) = op {
+                let n = self.vertex_bound();
+                if let (Some(src), Some(dst)) = (src.get(n), dst.get(n)) {
+                    if self.edge_exists(src, dst) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
+    }
+
+    fn edge_exists(&self, src: usize, dst: usize) -> bool {
+        self.neighbors
+            .iter()
+            .filter_map(Option::as_ref)
+            .copied()
+            .any(|(u, v)| u == src && v == dst || (!Ty::is_directed() && u == dst && v == src))
+    }
+}
+
+impl<V, E, Ty> GraphBase for Model<V, E, Ty> {
+    type VertexIndex = VertexIndex;
+    type EdgeIndex = EdgeIndex;
+}
+
+impl<V, E, Ty> VerticesBase for Model<V, E, Ty> {
+    type VertexIndicesIter<'a> = IndexIter<'a, VertexIndex, V>
+    where
+        Self: 'a;
+
+    fn vertex_count(&self) -> usize {
+        let holes = match self.params.removal_behavior {
+            RemovalBehavior::SwapRemove => 0,
+            RemovalBehavior::TombStone => self.removed_vertices,
+        };
+        self.vertices.len() - holes
+    }
+
+    fn vertex_bound(&self) -> usize {
+        self.vertices.len()
+    }
+
+    fn vertex_indices(&self) -> Self::VertexIndicesIter<'_> {
+        IndexIter::new(&self.vertices)
+    }
+}
+
+impl<V, E, Ty> Vertices<V> for Model<V, E, Ty> {
+    type VertexRef<'a> = (VertexIndex, &'a V)
+    where
+        Self: 'a,
+        V: 'a;
+
+    type VerticesIter<'a> = VerticesIter<'a, V>
+    where
+        Self: 'a,
+        V: 'a;
+
+    fn vertex(&self, index: &Self::VertexIndex) -> Option<&V> {
+        self.vertices.get(index.to_usize()).and_then(Option::as_ref)
+    }
+
+    fn vertices(&self) -> Self::VerticesIter<'_> {
+        VerticesIter::new(&self.vertices)
+    }
+}
+
+impl<V, E, Ty> VerticesMut<V> for Model<V, E, Ty> {
+    fn vertex_mut(&mut self, index: &Self::VertexIndex) -> Option<&mut V> {
+        self.vertices
+            .get_mut(index.to_usize())
+            .and_then(Option::as_mut)
+    }
+
+    fn try_add_vertex(&mut self, vertex: V) -> Result<Self::VertexIndex, AddVertexError<V>> {
+        if Some(self.vertex_count()) == self.params.max_vertex_count {
+            return Err(AddVertexError::new(vertex));
+        }
+
+        let index = VertexIndex::from_usize(self.vertices.len());
+        self.vertices.push(Some(vertex));
+
+        Ok(index)
+    }
+
+    fn remove_vertex(&mut self, index: &Self::VertexIndex) -> Option<V> {
+        self.vertex(index)?;
+
+        let index = index.to_usize();
+        self.removed_vertices += 1;
+
+        match self.params.removal_behavior {
+            RemovalBehavior::SwapRemove => {
+                let mut i = 0;
+                while i < self.edges.len() {
+                    if let Some(&(src, dst)) = self.neighbors[i].as_ref() {
+                        if src == index || dst == index {
+                            self.edges.swap_remove(i);
+                            self.neighbors.swap_remove(i);
+                            continue;
+                        }
+                    }
+
+                    i += 1;
+                }
+
+                self.vertices.swap_remove(index)
+            }
+            RemovalBehavior::TombStone => {
+                self.neighbors
+                    .iter_mut()
+                    .zip(self.edges.iter_mut())
+                    .filter(|(n, _)| {
+                        if let Some(&(src, dst)) = n.as_ref() {
+                            src == index || dst == index
+                        } else {
+                            false
+                        }
+                    })
+                    .for_each(|(n, e)| {
+                        n.take();
+                        e.take();
+                        self.removed_edges += 1;
+                    });
+
+                self.vertices[index].take()
+            }
+        }
+    }
+}
+
+impl<V, E, Ty: EdgeType> EdgesBase<Ty> for Model<V, E, Ty> {
+    type EdgeIndicesIter<'a> = IndexIter<'a, EdgeIndex, E>
+    where
+        Self: 'a;
+    type EdgeIndexIter<'a> = EdgeIndexIter<'a, Ty>
+    where
+        Self: 'a;
+
+    fn edge_count(&self) -> usize {
+        let holes = match self.params.removal_behavior {
+            RemovalBehavior::SwapRemove => 0,
+            RemovalBehavior::TombStone => self.removed_edges,
+        };
+        self.edges.len() - holes
+    }
+
+    fn edge_bound(&self) -> usize {
+        self.edges.len()
+    }
+
+    fn endpoints(&self, index: &Self::EdgeIndex) -> Option<(Self::VertexIndex, Self::VertexIndex)> {
+        let &(src, dst) = self.neighbors.get(index.to_usize())?.as_ref()?;
+        Some((VertexIndex::from_usize(src), VertexIndex::from_usize(dst)))
+    }
+
+    fn edge_index(
+        &self,
+        src: &Self::VertexIndex,
+        dst: &Self::VertexIndex,
+    ) -> Self::EdgeIndexIter<'_> {
+        let (src, dst) = (src.to_usize(), dst.to_usize());
+        EdgeIndexIter::new([src, dst], &self.neighbors)
+    }
+
+    fn edge_indices(&self) -> Self::EdgeIndicesIter<'_> {
+        IndexIter::new(&self.edges)
+    }
+}
+
+impl<V, E, Ty: EdgeType> Edges<E, Ty> for Model<V, E, Ty> {
+    type EdgeRef<'a> = (EdgeIndex, &'a E, VertexIndex, VertexIndex)
+    where
+        Self: 'a,
+        E: 'a;
+
+    type EdgesIter<'a> = EdgesIter<'a, E>
+    where
+        Self: 'a,
+        E: 'a;
+
+    fn edge(&self, index: &Self::EdgeIndex) -> Option<&E> {
+        self.edges.get(index.to_usize()).and_then(Option::as_ref)
+    }
+
+    fn edges(&self) -> Self::EdgesIter<'_> {
+        EdgesIter::new(&self.edges, &self.neighbors)
+    }
+}
+
+impl<V, E, Ty: EdgeType> EdgesMut<E, Ty> for Model<V, E, Ty> {
+    fn edge_mut(&mut self, index: &Self::EdgeIndex) -> Option<&mut E> {
+        self.edges
+            .get_mut(index.to_usize())
+            .and_then(Option::as_mut)
+    }
+
+    fn try_add_edge(
+        &mut self,
+        src: &Self::VertexIndex,
+        dst: &Self::VertexIndex,
+        edge: E,
+    ) -> Result<Self::EdgeIndex, AddEdgeError<E>> {
+        if self.vertex(src).is_none() {
+            return Err(AddEdgeError::new(edge, AddEdgeErrorKind::SourceAbsent));
+        }
+
+        if self.vertex(dst).is_none() {
+            return Err(AddEdgeError::new(edge, AddEdgeErrorKind::DestinationAbsent));
+        }
+
+        if Some(self.edge_count()) == self.params.max_edge_count {
+            return Err(AddEdgeError::new(edge, AddEdgeErrorKind::CapacityOverflow));
+        }
+
+        let (src, dst) = (src.to_usize(), dst.to_usize());
+
+        if !self.params.allow_multi_edges && self.edge_exists(src, dst) {
+            return Err(AddEdgeError::new(edge, AddEdgeErrorKind::MultiEdge));
+        }
+
+        let index = EdgeIndex::from_usize(self.edges.len());
+        self.edges.push(Some(edge));
+        self.neighbors.push(Some((src, dst)));
+
+        Ok(index)
+    }
+
+    fn remove_edge(&mut self, index: &Self::EdgeIndex) -> Option<E> {
+        self.edge(index)?;
+
+        let index = index.to_usize();
+        self.removed_edges += 1;
+
+        match self.params.removal_behavior {
+            RemovalBehavior::SwapRemove => {
+                self.neighbors.swap_remove(index);
+                self.edges.swap_remove(index)
+            }
+            RemovalBehavior::TombStone => {
+                self.neighbors[index].take();
+                self.edges[index].take()
+            }
+        }
+    }
+}
+
+impl<V, E, Ty: EdgeType> Neighbors for Model<V, E, Ty> {
+    type NeighborRef<'a> = (VertexIndex, EdgeIndex, VertexIndex, Direction)
+    where
+        Self: 'a;
+
+    type NeighborsIter<'a> = NeighborsIter<'a, Ty>
+    where
+        Self: 'a;
+
+    fn neighbors(&self, src: &Self::VertexIndex) -> Self::NeighborsIter<'_> {
+        NeighborsIter::new(src.to_usize(), &self.neighbors, None)
+    }
+
+    fn neighbors_directed(
+        &self,
+        src: &Self::VertexIndex,
+        dir: Direction,
+    ) -> Self::NeighborsIter<'_> {
+        NeighborsIter::new(src.to_usize(), &self.neighbors, Some(dir))
+    }
+}
+
+#[derive(Debug)]
+pub struct IndexIter<'a, Idx, T> {
+    data: &'a [Option<T>],
+    index: usize,
+    ty: PhantomData<Idx>,
+}
+
+impl<'a, Idx, T> IndexIter<'a, Idx, T> {
+    fn new(data: &'a [Option<T>]) -> Self {
+        Self {
+            data,
+            index: 0,
+            ty: PhantomData,
+        }
+    }
+}
+
+impl<Idx: NumIndexType, T> Iterator for IndexIter<'_, Idx, T> {
+    type Item = Idx;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (head, tail) = self.data.split_first()?;
+            self.data = tail;
+
+            if head.is_some() {
+                return Some(Idx::from_usize(self.index));
+            }
+
+            self.index += 1;
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct VerticesIter<'a, T> {
+    data: &'a [Option<T>],
+    index: usize,
+}
+
+impl<'a, T> VerticesIter<'a, T> {
+    pub fn new(data: &'a [Option<T>]) -> Self {
+        Self { data, index: 0 }
+    }
+}
+
+impl<'a, T> Iterator for VerticesIter<'a, T> {
+    type Item = (VertexIndex, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (head, tail) = self.data.split_first()?;
+            self.data = tail;
+
+            let index = VertexIndex::from_usize(self.index);
+            self.index += 1;
+
+            if let Some(value) = head {
+                return Some((index, value));
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EdgesIter<'a, T> {
+    data: &'a [Option<T>],
+    neighbors: &'a [Option<(usize, usize)>],
+    index: usize,
+}
+
+impl<'a, T> EdgesIter<'a, T> {
+    pub fn new(data: &'a [Option<T>], neighbors: &'a [Option<(usize, usize)>]) -> Self {
+        Self {
+            data,
+            neighbors,
+            index: 0,
+        }
+    }
+}
+
+impl<'a, T> Iterator for EdgesIter<'a, T> {
+    type Item = (EdgeIndex, &'a T, VertexIndex, VertexIndex);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (head, tail) = self.data.split_first()?;
+            self.data = tail;
+
+            let (pair, tail) = self.neighbors.split_first()?;
+            self.neighbors = tail;
+
+            let index = EdgeIndex::from_usize(self.index);
+            self.index += 1;
+
+            if let Some(value) = head {
+                let (src, dst) = pair.unwrap();
+                return Some((
+                    index,
+                    value,
+                    VertexIndex::from_usize(src),
+                    VertexIndex::from_usize(dst),
+                ));
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EdgeIndexIter<'a, Ty> {
+    between: [usize; 2],
+    neighbors: &'a [Option<(usize, usize)>],
+    index: usize,
+    ty: PhantomData<Ty>,
+}
+
+impl<'a, Ty> EdgeIndexIter<'a, Ty> {
+    pub fn new(between: [usize; 2], neighbors: &'a [Option<(usize, usize)>]) -> Self {
+        Self {
+            between,
+            neighbors,
+            index: 0,
+            ty: PhantomData,
+        }
+    }
+}
+
+impl<'a, Ty: EdgeType> Iterator for EdgeIndexIter<'a, Ty> {
+    type Item = EdgeIndex;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (pair, tail) = self.neighbors.split_first()?;
+            self.neighbors = tail;
+
+            let index = EdgeIndex::from_usize(self.index);
+            self.index += 1;
+
+            if let Some(&(src, dst)) = pair.as_ref() {
+                let src_dst = src == self.between[0] && dst == self.between[1];
+                let dst_src =
+                    !Ty::is_directed() && dst == self.between[0] && src == self.between[1];
+
+                if src_dst || dst_src {
+                    return Some(index);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct NeighborsIter<'a, Ty> {
+    src: usize,
+    neighbors: &'a [Option<(usize, usize)>],
+    dir: Option<Direction>,
+    index: usize,
+    ty: PhantomData<Ty>,
+}
+
+impl<'a, Ty> NeighborsIter<'a, Ty> {
+    pub fn new(
+        src: usize,
+        neighbors: &'a [Option<(usize, usize)>],
+        dir: Option<Direction>,
+    ) -> Self {
+        Self {
+            src,
+            neighbors,
+            dir,
+            index: 0,
+            ty: PhantomData,
+        }
+    }
+}
+
+impl<'a, Ty: EdgeType> Iterator for NeighborsIter<'a, Ty> {
+    type Item = (VertexIndex, EdgeIndex, VertexIndex, Direction);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (pair, tail) = self.neighbors.split_first()?;
+            self.neighbors = tail;
+
+            let index = EdgeIndex::from_usize(self.index);
+            self.index += 1;
+
+            match (pair.as_ref(), self.dir, Ty::is_directed()) {
+                // If vertex matches source and the graph is undirected.
+                (Some(&(src, dst)), _, false)
+                // If the vertex matches source and the graph is directed but
+                // the direction does not matter.
+                | (Some(&(src, dst)), None, true)
+                // If the vertex matches source and the graph is directed and
+                // the direction is outgoing.
+                | (Some(&(src, dst)), Some(Direction::Outgoing), true)
+                    if src == self.src =>
+                {
+                    return Some((
+                        VertexIndex::from_usize(dst),
+                        index,
+                        VertexIndex::from_usize(src),
+                        Direction::Outgoing,
+                    ));
+                }
+                // If the vertex matches destination and the graph is
+                // undirected, we still consider the edge outgoing.
+                (Some(&(src, dst)), _, false) if dst == self.src => {
+                    return Some((
+                        VertexIndex::from_usize(src),
+                        index,
+                        VertexIndex::from_usize(dst),
+                        Direction::Outgoing,
+                    ));
+                }
+                // If the vertex matches destination and the graph is directed
+                // but the direction does not matter.
+                (Some(&(src, dst)), None, true)
+                // If the vertex matches destination and the graph is directed
+                // and the direction is incoming.
+                | (Some(&(src, dst)), Some(Direction::Incoming), true)
+                    if dst == self.src =>
+                {
+                    return Some((
+                        VertexIndex::from_usize(src),
+                        index,
+                        VertexIndex::from_usize(dst),
+                        Direction::Incoming,
+                    ));
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/src/infra/proptest.rs
+++ b/src/infra/proptest.rs
@@ -1,76 +1,720 @@
-use std::{fmt::Debug, marker::PhantomData};
+use std::{collections::BTreeMap, fmt, marker::PhantomData};
 
 use proptest::{
-    arbitrary::{any, Arbitrary},
-    strategy::Strategy,
+    prelude::Rng,
+    strategy::{Strategy, ValueTree},
+};
+use rustc_hash::FxHashSet;
+
+use crate::{
+    core::{
+        marker::{Directed, EdgeType, Undirected},
+        Create, EdgesMut, VerticesMut,
+    },
+    Graph,
 };
 
-use crate::core::{index::NumIndexType, marker::EdgeType, Create};
+use super::testing::AsDot;
 
-use super::testing::{Applier, ApplyMutOps, ApplyOptions, MutOp};
-
-// For testing correctness of storages.
-pub fn graph_ops_strategy<V, E, Ty: EdgeType, G>() -> impl Strategy<Value = G>
-where
-    V: Arbitrary + Debug,
-    E: Arbitrary + Debug,
-    Ty: Debug,
-    G: Create<V, E, Ty> + Debug,
-    G::VertexIndex: NumIndexType,
-{
-    graph_ops_strategy_with(ApplyOptions::default())
+pub fn graph<V: Strategy, E: Strategy, Ty: EdgeType>(
+    vertex: V,
+    edge: E,
+) -> GraphStrategy<V, E, Ty> {
+    GraphStrategy::new(vertex, edge)
 }
 
-pub fn graph_ops_strategy_with<V, E, Ty: EdgeType, G>(
-    options: ApplyOptions,
-) -> impl Strategy<Value = G>
-where
-    V: Arbitrary + Debug,
-    E: Arbitrary + Debug,
-    Ty: Debug,
-    G: Create<V, E, Ty> + Debug,
-    G::VertexIndex: NumIndexType,
-{
-    any::<Vec<MutOp<V, E, Ty>>>().prop_map(move |ops| {
-        let mut graph = G::with_capacity(ops.len(), ops.len());
-        let mut applier = Applier::with_options(&mut graph, options);
-        applier.apply_many(ops.into_iter());
-        graph
-    })
+pub fn graph_undirected<V: Strategy, E: Strategy>(
+    vertex: V,
+    edge: E,
+) -> GraphStrategy<V, E, Undirected> {
+    GraphStrategy::new(vertex, edge)
 }
 
-pub fn graph_strategy<V, E, Ty: EdgeType, G>() -> impl Strategy<Value = G>
-where
-    V: Arbitrary + Debug,
-    E: Arbitrary + Debug,
-    Ty: Debug,
-    G: Create<V, E, Ty> + Debug,
-    G::VertexIndex: NumIndexType,
-{
-    graph_strategy_with(ApplyOptions::default())
+pub fn graph_directed<V: Strategy, E: Strategy>(
+    vertex: V,
+    edge: E,
+) -> GraphStrategy<V, E, Directed> {
+    GraphStrategy::new(vertex, edge)
 }
 
-pub fn graph_strategy_with<V, E, Ty: EdgeType, G>(options: ApplyOptions) -> impl Strategy<Value = G>
+#[derive(Debug, Clone)]
+pub struct GraphValueTree<V: ValueTree, E: ValueTree, Ty: EdgeType, G> {
+    vertices: Vec<V>,
+    edges: Vec<(usize, usize, E)>,
+    structure: Option<ShrinkStructureState>,
+    data: Option<ShrinkDataState>,
+    ty: PhantomData<Ty>,
+    graph: PhantomData<G>,
+}
+
+pub struct GraphStrategy<
+    V: Strategy,
+    E: Strategy,
+    Ty: EdgeType,
+    G = Graph<<V as Strategy>::Value, <E as Strategy>::Value, Ty>,
+> {
+    vertex: V,
+    edge: E,
+    ty: PhantomData<Ty>,
+    graph: PhantomData<G>,
+    params: StrategyParams,
+}
+
+// G is phantom data, we should not require Debug bound on it.
+impl<V: Strategy, E: Strategy, Ty: EdgeType, G> fmt::Debug for GraphStrategy<V, E, Ty, G> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GraphStrategy")
+            .field("vertex", &self.vertex)
+            .field("edge", &self.edge)
+            .field("ty", &self.ty)
+            .field("graph", &self.graph)
+            .field("params", &self.params)
+            .finish()
+    }
+}
+
+macro_rules! delegate_builder_fn {
+    ($name:ident$(, $param:ident: $param_type:ty)*) => {
+        #[doc = concat!("See [StrategyParams::", stringify!($name), "](StrategyParams::", stringify!($name), ") for details.")]
+        pub fn $name(self, $($param: $param_type),*) -> Self {
+            Self {
+                params: self.params.$name($($param,)*),
+                ..self
+            }
+        }
+    }
+}
+
+impl<V: Strategy, E: Strategy, Ty: EdgeType> GraphStrategy<V, E, Ty> {
+    pub fn new(vertex: V, edge: E) -> Self {
+        Self::with_params(vertex, edge, StrategyParams::default())
+    }
+
+    pub fn new_in<G>(vertex: V, edge: E) -> GraphStrategy<V, E, Ty, G> {
+        GraphStrategy::with_params_in(vertex, edge, StrategyParams::default())
+    }
+
+    pub fn with_params(vertex: V, edge: E, params: StrategyParams) -> Self {
+        Self {
+            vertex,
+            edge,
+            ty: PhantomData,
+            graph: PhantomData,
+            params,
+        }
+    }
+
+    pub fn with_params_in<G>(
+        vertex: V,
+        edge: E,
+        params: StrategyParams,
+    ) -> GraphStrategy<V, E, Ty, G> {
+        GraphStrategy {
+            vertex,
+            edge,
+            ty: PhantomData,
+            graph: PhantomData,
+            params,
+        }
+    }
+
+    // Builder pattern on the strategy itself to allow usage as in
+    // `graph(0..10, 0..10).max_size(100).acyclic()`.
+    delegate_builder_fn!(max_size, max_size: usize);
+    delegate_builder_fn!(acyclic);
+    delegate_builder_fn!(connected);
+    delegate_builder_fn!(allow_loops);
+    delegate_builder_fn!(multi_edge_prob, multi_edge_prob: f32);
+    delegate_builder_fn!(model, model: RandomModel);
+    delegate_builder_fn!(class, class: GraphClass);
+    delegate_builder_fn!(density, density: f32);
+    delegate_builder_fn!(sparse);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RandomModel {
+    ErdosRenyi,
+    WattsStrogatz,
+    BarabasiAlbert,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphClass {
+    Forest,
+    Bipartite,
+}
+
+#[derive(Debug)]
+pub struct StrategyParams {
+    max_size: usize,
+    acyclic: bool,
+    connected: bool,
+    allow_loops: bool,
+    multi_edge_prob: f32,
+    model: RandomModel,
+    class: Option<GraphClass>,
+    // (0, 1] - 1 means no limitation in choosing p, lower values artificially decrease chosen p
+    density: f32,
+}
+
+impl Default for StrategyParams {
+    fn default() -> Self {
+        Self {
+            max_size: 512,
+            acyclic: false,
+            connected: false,
+            allow_loops: false,
+            multi_edge_prob: 0.0,
+            model: RandomModel::ErdosRenyi,
+            class: None,
+            density: 1.0,
+        }
+    }
+}
+
+impl StrategyParams {
+    pub fn max_size(self, max_size: usize) -> Self {
+        Self { max_size, ..self }
+    }
+
+    pub fn acyclic(self) -> Self {
+        Self {
+            acyclic: true,
+            ..self
+        }
+    }
+
+    pub fn connected(self) -> Self {
+        Self {
+            connected: true,
+            ..self
+        }
+    }
+
+    pub fn allow_loops(self) -> Self {
+        Self {
+            allow_loops: true,
+            ..self
+        }
+    }
+
+    pub fn multi_edge_prob(self, multi_edge_prob: f32) -> Self {
+        assert!(
+            (0.0..=0.1).contains(&multi_edge_prob),
+            "multi edge probability must be in [0, 0.1] range"
+        );
+        Self {
+            multi_edge_prob,
+            ..self
+        }
+    }
+
+    pub fn model(self, model: RandomModel) -> Self {
+        Self { model, ..self }
+    }
+
+    pub fn class(self, class: GraphClass) -> Self {
+        Self {
+            class: Some(class),
+            ..self
+        }
+    }
+
+    pub fn density(self, density: f32) -> Self {
+        assert!(
+            density > 0.0 && density <= 1.0,
+            "density must be in (0, 1] range"
+        );
+        Self { density, ..self }
+    }
+
+    pub fn sparse(self) -> Self {
+        self.density(0.05)
+    }
+}
+
+impl<V: Strategy, E: Strategy, Ty: EdgeType, G> Strategy for GraphStrategy<V, E, Ty, G>
 where
-    V: Arbitrary + Debug,
-    E: Arbitrary + Debug,
-    Ty: Debug,
-    G: Create<V, E, Ty> + Debug,
-    G::VertexIndex: NumIndexType,
+    G: VerticesMut<V::Value> + EdgesMut<E::Value, Ty> + Create<V::Value, E::Value, Ty>,
 {
-    (any::<Vec<V>>(), any::<Vec<(usize, usize, E)>>()).prop_map(move |(vertices, edges)| {
-        let vertex_count = vertices.len();
-        let edge_count = edges.len();
+    type Tree = GraphValueTree<V::Tree, E::Tree, Ty, G>;
+    type Value = AsDot<V::Value, E::Value, Ty, G>;
 
-        let vertices = vertices.into_iter().map(|v| MutOp::AddVertex(v));
-        let edges = edges
-            .into_iter()
-            .map(|(src, dst, e)| MutOp::AddEdge(src, dst, e, PhantomData));
-        let ops = vertices.chain(edges);
+    fn new_tree(
+        &self,
+        runner: &mut proptest::test_runner::TestRunner,
+    ) -> proptest::strategy::NewTree<Self> {
+        assert!(
+            self.params.model == RandomModel::ErdosRenyi,
+            "generation of graphs in other models is not supported yet"
+        );
 
-        let mut graph = G::with_capacity(vertex_count, edge_count);
-        let mut applier = Applier::with_options(&mut graph, options);
-        applier.apply_many(ops);
-        graph
-    })
+        let n = runner.rng().gen_range(0..=self.params.max_size);
+        let p = runner.rng().gen::<f32>() * self.params.density;
+
+        // Efficient generation of large random networks
+        // http://vlado.fmf.uni-lj.si/pub/networks/doc/ms/rndgen.pdf
+
+        let mut vertices = Vec::with_capacity(n);
+
+        while vertices.len() < n {
+            vertices.push(self.vertex.new_tree(runner)?);
+        }
+
+        let m_guess = if n > 0 {
+            ((n * (n - 1) / 2) as f32 * p).round() as usize
+        } else {
+            0
+        };
+        let mut edges = Vec::with_capacity(m_guess);
+
+        let mut v = 1;
+        let mut w = usize::MAX; // -1
+
+        while v < n {
+            let r: f32 = runner.rng().gen();
+            w = w.wrapping_add(1) + ((1.0 - r).log10() / (1.0 - p).log10()).floor() as usize;
+
+            if self.params.allow_loops {
+                // Using `w > v` instead of `w >= v` to allow loops.
+                while w > v && v < n {
+                    w -= v;
+                    v += 1;
+                }
+            } else {
+                while w >= v && v < n {
+                    w -= v;
+                    v += 1;
+                }
+            }
+
+            if v < n {
+                if self.params.class == Some(GraphClass::Bipartite) {
+                    // If the vertices belong to the same partition, determined
+                    // by odd/even test, do not add the edge.
+                    if v % 2 == w % 2 {
+                        continue;
+                    }
+                }
+
+                let e = self.edge.new_tree(runner)?;
+
+                // For directed acyclic graph or in half of the cases, pick the
+                // vertices such that v < w. In other cases, swap the vertices
+                // so that a directed cycle is possible.
+                let (s, t) =
+                    if Ty::is_directed() && self.params.acyclic || runner.rng().gen_bool(0.5) {
+                        (w, v)
+                    } else {
+                        (v, w)
+                    };
+
+                edges.push((s, t, e));
+
+                // Possibly add multi edges.
+                while runner.rng().gen_bool(self.params.multi_edge_prob as f64) {
+                    let e = self.edge.new_tree(runner)?;
+                    edges.push((s, t, e));
+                }
+            }
+        }
+
+        if self.params.connected {
+            panic!("connected graphs are not supported yet");
+
+            // TODO: Identify all connected components and connect these
+            // components with new edges.
+        }
+
+        if (!Ty::is_directed() && self.params.acyclic)
+            || self.params.class == Some(GraphClass::Forest)
+        {
+            panic!("acyclic undirected graphs or forests are not supported yet");
+
+            // TODO: Run BFS to get a spanning tree and remove all edges that do
+            // not belong to the spanning tree.
+        }
+
+        Ok(GraphValueTree {
+            vertices,
+            edges,
+            structure: None,
+            data: None,
+            ty: PhantomData,
+            graph: PhantomData,
+        })
+    }
+}
+
+impl<V: ValueTree, E: ValueTree, Ty: EdgeType, G> ValueTree for GraphValueTree<V, E, Ty, G>
+where
+    G: VerticesMut<V::Value> + EdgesMut<E::Value, Ty> + Create<V::Value, E::Value, Ty>,
+{
+    type Value = AsDot<V::Value, E::Value, Ty, G>;
+
+    fn current(&self) -> Self::Value {
+        let empty = FxHashSet::default();
+        let (removed_vertices, removed_edges) = match self.structure {
+            Some(ref state) => (
+                &state.current.removed_vertices,
+                &state.current.removed_edges,
+            ),
+            None => (&empty, &empty),
+        };
+
+        let mut graph = G::with_capacity(
+            self.vertices.len() - removed_vertices.len(),
+            self.edges.len() - removed_edges.len(),
+        );
+        let mut indices = Vec::with_capacity(self.vertices.len());
+
+        for (v, vertex) in self.vertices.iter().enumerate() {
+            if !removed_vertices.contains(&v) {
+                indices.push(Some(graph.add_vertex(vertex.current())));
+            } else {
+                indices.push(None);
+            }
+        }
+
+        for (e, (src, dst, edge)) in self.edges.iter().enumerate() {
+            if !removed_edges.contains(&e)
+                && !removed_vertices.contains(src)
+                && !removed_vertices.contains(dst)
+            {
+                let src = indices[*src].as_ref().unwrap();
+                let dst = indices[*dst].as_ref().unwrap();
+                graph.add_edge(src, dst, edge.current());
+            }
+        }
+
+        AsDot::new(graph)
+    }
+
+    fn simplify(&mut self) -> bool {
+        // The strategy is fundamentally the same as for example default
+        // strategy for Vec. First, we try to simplify the structure as much as
+        // possible, then we switch to simplifying the data of vertices and
+        // edges.
+        //
+        // The structure simplification starts with removing all vertices with
+        // low degree. The idea is that this should get rid off uninteresting
+        // parts of the graph very quickly thanks to its agresivity (many
+        // vertices at once). Then we apply the standard strategy of simplifying
+        // vertex and edge one by one, respectively. The same strategy is then
+        // applied on the data.
+        //
+        // It is useful to start with vertices and then move to edges, because
+        // successful removals of vertices may also remove some edges, having
+        // larger effect than just removing edges individually.
+
+        let structure = self
+            .structure
+            .get_or_insert_with(|| ShrinkStructureState::new(&self.vertices, &self.edges));
+        let data = self.data.get_or_insert_with(ShrinkDataState::new);
+
+        structure.simplify(&self.vertices, &self.edges)
+            || data.simplify(&mut self.vertices, &mut self.edges, structure)
+    }
+
+    fn complicate(&mut self) -> bool {
+        // The state is available, because it is initialized in simplify.
+        let structure = self.structure.as_mut().unwrap();
+        let data = self.data.as_mut().unwrap();
+
+        structure.complicate(&self.vertices, &self.edges)
+            || data.complicate(&mut self.vertices, &mut self.edges)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShrinkStructure {
+    VertexWithDegree,
+    Vertex(usize),
+    Edge(usize),
+}
+
+#[derive(Debug, Clone)]
+struct Removed {
+    removed_vertices: FxHashSet<usize>,
+    removed_edges: FxHashSet<usize>,
+}
+
+#[derive(Debug, Clone)]
+struct ShrinkStructureState {
+    current: Removed,
+    high: Option<Removed>,
+    command: Option<ShrinkStructure>,
+    neighbors_out: BTreeMap<(usize, usize), usize>,
+    neighbors_in: BTreeMap<(usize, usize), usize>,
+}
+
+impl ShrinkStructureState {
+    pub fn new<V, E>(_vertices: &[V], edges: &[(usize, usize, E)]) -> Self {
+        let mut neighbors_out = BTreeMap::new();
+        let mut neighbors_in = BTreeMap::new();
+
+        for &(src, dst, _) in edges {
+            *neighbors_out.entry((src, dst)).or_default() += 1;
+            *neighbors_in.entry((dst, src)).or_default() += 1;
+        }
+
+        Self {
+            current: Removed {
+                removed_vertices: Default::default(),
+                removed_edges: Default::default(),
+            },
+            high: None,
+            command: Some(ShrinkStructure::VertexWithDegree),
+            neighbors_out,
+            neighbors_in,
+        }
+    }
+
+    pub fn simplify<V, E>(&mut self, vertices: &[V], edges: &[(usize, usize, E)]) -> bool {
+        let command = match self.command {
+            Some(command) => command,
+            None => return false,
+        };
+
+        if self.current.removed_vertices.len() == vertices.len() {
+            // Empty graph.
+            return false;
+        }
+
+        self.high = Some(self.current.clone());
+
+        let (remove_vertices, remove_edges, command) = match command {
+            ShrinkStructure::VertexWithDegree => {
+                let min_degree = (0..vertices.len())
+                    .filter(|&v| self.vertex_exists(v))
+                    .map(|v| self.degree(v))
+                    .min()
+                    .unwrap_or_default();
+
+                let remove = (0..vertices.len())
+                    .filter(|&v| self.vertex_exists(v))
+                    .filter(|&v| self.degree(v) == min_degree)
+                    .collect::<Vec<_>>();
+
+                (remove, Vec::new(), Some(ShrinkStructure::VertexWithDegree))
+            }
+            ShrinkStructure::Vertex(v) => (vec![v], Vec::new(), self.next_command(vertices, edges)),
+            ShrinkStructure::Edge(e) => (Vec::new(), vec![e], self.next_command(vertices, edges)),
+        };
+
+        for v in remove_vertices {
+            self.current.removed_vertices.insert(v);
+
+            for neighbors in [&mut self.neighbors_out, &mut self.neighbors_in] {
+                neighbors.retain(|&(src, dst), _| !(src == v || dst == v));
+            }
+        }
+
+        for e in remove_edges {
+            let (src, dst, _) = edges[e];
+
+            self.current.removed_edges.insert(e);
+            self.neighbors_in.remove(&(src, dst));
+            self.neighbors_in.remove(&(dst, src));
+        }
+
+        self.command = command;
+        true
+    }
+
+    pub fn complicate<V, E>(&mut self, vertices: &[V], edges: &[(usize, usize, E)]) -> bool {
+        self.current = match self.high.take() {
+            Some(high) => high,
+            None => return false,
+        };
+
+        if self.command == Some(ShrinkStructure::VertexWithDegree) {
+            self.command = self.next_command(vertices, edges);
+        }
+
+        true
+    }
+
+    fn degree(&self, v: usize) -> usize {
+        self.neighbors_out
+            .range((v, 0)..=(v, usize::MAX))
+            .chain(self.neighbors_in.range((v, 0)..=(v, usize::MAX)))
+            .map(|(_, d)| d)
+            .sum()
+    }
+
+    fn vertex_exists(&self, v: usize) -> bool {
+        !self.current.removed_vertices.contains(&v)
+    }
+
+    fn edge_exists(&self, e: usize, (src, dst): (usize, usize)) -> bool {
+        !(self.current.removed_vertices.contains(&src)
+            || self.current.removed_vertices.contains(&dst)
+            || self.current.removed_edges.contains(&e))
+    }
+
+    fn next_command<V, E>(
+        &mut self,
+        vertices: &[V],
+        edges: &[(usize, usize, E)],
+    ) -> Option<ShrinkStructure> {
+        match self.command? {
+            ShrinkStructure::VertexWithDegree => (0..vertices.len())
+                .find(|&v| self.vertex_exists(v))
+                .map(ShrinkStructure::Vertex),
+            ShrinkStructure::Vertex(v) => ((v + 1)..vertices.len())
+                .find(|&w| self.vertex_exists(w))
+                .map(ShrinkStructure::Vertex)
+                .or_else(|| {
+                    (0..edges.len())
+                        .find(|&e| {
+                            let (src, dst, _) = edges[e];
+                            self.edge_exists(e, (src, dst))
+                        })
+                        .map(ShrinkStructure::Edge)
+                }),
+            ShrinkStructure::Edge(e) => ((e + 1)..edges.len())
+                .find(|&f| {
+                    let (src, dst, _) = edges[f];
+                    self.edge_exists(f, (src, dst))
+                })
+                .map(ShrinkStructure::Edge),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShrinkData {
+    Vertex(usize),
+    Edge(usize),
+}
+
+#[derive(Debug, Clone)]
+struct ShrinkDataState {
+    command: ShrinkData,
+    previous: Option<ShrinkData>,
+}
+
+// The implementation is adapted from VecValueTree
+// (https://github.com/proptest-rs/proptest/blob/ef305c4fadd7c0ba13a349f542da00d290116ccb/proptest/src/collection.rs#L603-L672).
+impl ShrinkDataState {
+    pub fn new() -> Self {
+        Self {
+            command: ShrinkData::Vertex(0),
+            previous: None,
+        }
+    }
+
+    pub fn simplify<V, E>(
+        &mut self,
+        vertices: &mut [V],
+        edges: &mut [(usize, usize, E)],
+        structure: &ShrinkStructureState,
+    ) -> bool
+    where
+        V: ValueTree,
+        E: ValueTree,
+    {
+        loop {
+            match self.command {
+                ShrinkData::Vertex(v) => {
+                    if v >= vertices.len() {
+                        self.command = ShrinkData::Edge(0);
+                    } else if structure.vertex_exists(v) && vertices[v].simplify() {
+                        self.previous = Some(self.command);
+                        return true;
+                    } else {
+                        self.command = ShrinkData::Vertex(v + 1);
+                    }
+                }
+                ShrinkData::Edge(e) => {
+                    if e >= edges.len() {
+                        return false;
+                    } else {
+                        let (src, dst, edge) = &mut edges[e];
+                        if structure.edge_exists(e, (*src, *dst)) && edge.simplify() {
+                            self.previous = Some(self.command);
+                            return true;
+                        } else {
+                            self.command = ShrinkData::Edge(e + 1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn complicate<V, E>(&mut self, vertices: &mut [V], edges: &mut [(usize, usize, E)]) -> bool
+    where
+        V: ValueTree,
+        E: ValueTree,
+    {
+        match self.previous {
+            None => false,
+            Some(ShrinkData::Vertex(v)) => {
+                if vertices[v].complicate() {
+                    true
+                } else {
+                    self.previous = None;
+                    false
+                }
+            }
+            Some(ShrinkData::Edge(e)) => {
+                if edges[e].2.complicate() {
+                    true
+                } else {
+                    self.previous = None;
+                    false
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::{strategy::check_strategy_sanity, test_runner::TestRunner};
+
+    use crate::core::{EdgeRef, Edges, EdgesBase, VertexRef, Vertices, VerticesBase};
+
+    use super::*;
+
+    #[test]
+    #[ignore = "takes too long, run it only when the strategy is changed"]
+    fn graph_strategy_sanity() {
+        check_strategy_sanity(graph_undirected(0..100, 0..100).max_size(16), None);
+    }
+
+    #[test]
+    fn simplifies_structure_and_data() {
+        let strategy = graph_undirected(0..100, 0..100).max_size(64);
+        let mut tree = strategy.new_tree(&mut TestRunner::deterministic()).unwrap();
+
+        loop {
+            let graph = tree.current();
+
+            if graph.vertex_count() < 1 || graph.edge_count() < 1 {
+                if !tree.complicate() {
+                    break;
+                }
+            } else if !tree.simplify() {
+                break;
+            }
+        }
+
+        let graph = tree.current();
+
+        // No loops and multi edges => two vertices connected with one edge.
+        assert_eq!(graph.vertex_count(), 2);
+        assert_eq!(graph.edge_count(), 1);
+
+        // Data simplified too.
+        for vertex in graph.vertices() {
+            assert_eq!(*vertex.data(), 0);
+        }
+
+        for edge in graph.edges() {
+            assert_eq!(*edge.data(), 0);
+        }
+    }
 }

--- a/src/infra/testing.rs
+++ b/src/infra/testing.rs
@@ -262,7 +262,7 @@ mod random {
                             return;
                         }
 
-                        if !self.options.multi_edges && self.graph.edge_index(&src, &dst).is_some()
+                        if !self.options.multi_edges && self.graph.edge_index_any(&src, &dst).is_some()
                         {
                             return;
                         }
@@ -279,7 +279,7 @@ mod random {
                         let map = self.graph.vertex_index_map();
                         let src = map.real(src % self.graph.vertex_count()).unwrap();
                         let dst = map.real(dst % self.graph.vertex_count()).unwrap();
-                        if let Some(index) = self.graph.edge_index(&src, &dst) {
+                        if let Some(index) = self.graph.edge_index_any(&src, &dst) {
                             self.graph.remove_edge(&index);
                         }
                     }

--- a/src/ops/complement.rs
+++ b/src/ops/complement.rs
@@ -65,7 +65,7 @@ where
 
         for u in self.graph.vertex_indices() {
             for v in self.graph.vertex_indices() {
-                if u < v && self.graph.edge_index(&u, &v).is_none() {
+                if u < v && self.graph.edge_index_any(&u, &v).is_none() {
                     let u = NumIndexType::from_usize(vertex_map.virt(u).unwrap().to_usize());
                     let v = NumIndexType::from_usize(vertex_map.virt(v).unwrap().to_usize());
                     result.add_edge(&u, &v, self.edge.clone());
@@ -206,13 +206,13 @@ mod tests {
 
         let complement: AdjList<_, _, _, _> = Complement::new(graph, ()).apply();
 
-        assert!(complement.edge_index(&v0, &v1).is_none());
-        assert!(complement.edge_index(&v1, &v2).is_none());
-        assert!(complement.edge_index(&v2, &v3).is_none());
-        assert!(complement.edge_index(&v3, &v1).is_none());
+        assert!(complement.edge_index_any(&v0, &v1).is_none());
+        assert!(complement.edge_index_any(&v1, &v2).is_none());
+        assert!(complement.edge_index_any(&v2, &v3).is_none());
+        assert!(complement.edge_index_any(&v3, &v1).is_none());
 
-        assert!(complement.edge_index(&v0, &v3).is_some());
-        assert!(complement.edge_index(&v0, &v2).is_some());
+        assert!(complement.edge_index_any(&v0, &v3).is_some());
+        assert!(complement.edge_index_any(&v0, &v2).is_some());
     }
 
     #[test]
@@ -282,12 +282,12 @@ mod tests {
         let v2 = VertexIndex::from(2);
         let v4 = VertexIndex::from(3);
 
-        assert!(complement.edge_index(&v0, &v1).is_none());
-        assert!(complement.edge_index(&v1, &v2).is_none());
-        assert!(complement.edge_index(&v4, &v1).is_none());
+        assert!(complement.edge_index_any(&v0, &v1).is_none());
+        assert!(complement.edge_index_any(&v1, &v2).is_none());
+        assert!(complement.edge_index_any(&v4, &v1).is_none());
 
-        assert!(complement.edge_index(&v0, &v2).is_some());
-        assert!(complement.edge_index(&v0, &v4).is_some());
-        assert!(complement.edge_index(&v2, &v4).is_some());
+        assert!(complement.edge_index_any(&v0, &v2).is_some());
+        assert!(complement.edge_index_any(&v0, &v4).is_some());
+        assert!(complement.edge_index_any(&v2, &v4).is_some());
     }
 }

--- a/src/ops/transpose.rs
+++ b/src/ops/transpose.rs
@@ -79,6 +79,9 @@ where
     type EdgeIndicesIter<'a> = G::EdgeIndicesIter<'a>
     where
         Self: 'a;
+    type EdgeIndexIter<'a> = G::EdgeIndexIter<'a>
+    where
+        Self: 'a;
 
     fn edge_count(&self) -> usize {
         self.graph.edge_count()
@@ -96,8 +99,16 @@ where
         &self,
         src: &Self::VertexIndex,
         dst: &Self::VertexIndex,
-    ) -> Option<Self::EdgeIndex> {
+    ) -> Self::EdgeIndexIter<'_> {
         self.graph.edge_index(dst, src)
+    }
+
+    fn edge_index_any(
+        &self,
+        src: &Self::VertexIndex,
+        dst: &Self::VertexIndex,
+    ) -> Option<Self::EdgeIndex> {
+        self.graph.edge_index_any(dst, src)
     }
 
     fn edge_indices(&self) -> Self::EdgeIndicesIter<'_> {
@@ -266,8 +277,8 @@ mod tests {
     fn edge_index() {
         let graph = Transpose::new(create_graph());
 
-        assert_eq!(graph.edge_index(&2.into(), &1.into()), Some(1.into()));
-        assert_eq!(graph.edge_index(&1.into(), &2.into()), Some(3.into()));
+        assert_eq!(graph.edge_index_any(&2.into(), &1.into()), Some(1.into()));
+        assert_eq!(graph.edge_index_any(&1.into(), &2.into()), Some(3.into()));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -49,7 +49,7 @@ mod tests {
 
         let valid_edge_indices = graph.edge_indices().all(|edge_index| {
             let (src, dst) = graph.endpoints(&edge_index).unwrap();
-            graph.edge_index(&src, &dst) == Some(edge_index)
+            graph.edge_index_any(&src, &dst) == Some(edge_index)
         });
         assert!(valid_edge_indices);
 
@@ -96,7 +96,7 @@ mod tests {
 
     pub fn test_multi<Ty: EdgeType, G>()
     where
-        G: Create<(), i32, Ty> + MultiEdges<i32, Ty>,
+        G: Create<(), i32, Ty> + MultiEdges<Ty>,
     {
         let mut graph = G::default();
 
@@ -109,14 +109,14 @@ mod tests {
         graph.add_edge(&v0, &v1, 2);
 
         let mut e01 = graph
-            .multi_edge_index(&v0, &v1)
+            .edge_index(&v0, &v1)
             .map(|e| graph.edge(&e))
             .collect::<Vec<_>>();
 
         e01.sort();
 
         let e02 = graph
-            .multi_edge_index(&v0, &v2)
+            .edge_index(&v0, &v2)
             .map(|e| graph.edge(&e))
             .collect::<Vec<_>>();
 

--- a/src/storage/adj_list.rs
+++ b/src/storage/adj_list.rs
@@ -561,6 +561,10 @@ mod tests {
             index::DefaultIndexing,
             marker::{Directed, Undirected},
         },
+        infra::{
+            arbitrary::{ArbitraryIndexing, Index},
+            testing::check_consistency,
+        },
         storage::tests::*,
     };
 
@@ -592,5 +596,28 @@ mod tests {
     #[test]
     fn connect_vertices_directed() {
         test_connect_vertices::<Directed, AdjList<_, _, _, DefaultIndexing>>();
+    }
+
+    #[test]
+    #[ignore = "not fixed yet"]
+    fn fuzz_trophy1() {
+        let mut graph = AdjList::<_, _, Undirected, ArbitraryIndexing>::new();
+
+        graph.add_vertex(0);
+        graph.add_edge(&Index(0), &Index(0), -68);
+        graph.clear_edges();
+        graph.remove_edge_between(&Index(0), &Index(0));
+    }
+
+    #[test]
+    #[ignore = "not fixed yet"]
+    fn fuzz_trophy2() {
+        let mut graph = AdjList::<_, _, Directed, ArbitraryIndexing>::new();
+
+        graph.add_vertex(5);
+        graph.add_edge(&Index(0), &Index(0), -1);
+        graph.clear_edges();
+
+        check_consistency(&graph).unwrap();
     }
 }

--- a/src/storage/adj_matrix.rs
+++ b/src/storage/adj_matrix.rs
@@ -185,6 +185,9 @@ where
     type EdgeIndicesIter<'a> = EdgeIndicesIter<'a, Ty, Ix>
     where
         Self: 'a;
+    type EdgeIndexIter<'a> = std::option::IntoIter<Self::EdgeIndex>
+    where
+        Self: 'a;
 
     fn edge_count(&self) -> usize {
         self.n_edges
@@ -207,9 +210,9 @@ where
         &self,
         src: &Self::VertexIndex,
         dst: &Self::VertexIndex,
-    ) -> Option<Self::EdgeIndex> {
+    ) -> Self::EdgeIndexIter<'_> {
         let index = self.matrix.index(src.to_usize(), dst.to_usize());
-        self.matrix.get(index).map(|_| index)
+        self.matrix.get(index).map(|_| index).into_iter()
     }
 
     fn edge_indices(&self) -> Self::EdgeIndicesIter<'_> {


### PR DESCRIPTION
This PR establishes an infrastructure for correctness testing using fuzzing and property-based testing. There are two main areas:

* Graph storages
* Algorithms

### Graph storages

For graph storages, we will mainly employ **fuzzing** with [stateful modeling](https://propertesting.com/book_stateful_properties.html) of a graph behavior. For that, we have a `MutOp` enum which represents common graph manipulating operations. The test input is a sequence of such operations, either completely random or guided via `MutOpsSeq`. The operations are then applied on a graph under test. There are three levels of such testing:

1. The graph does not panic while doing an operation.
2. The graph is in a consistent state after each operation. For this, there is the `check_consistency` utility function.
3. The graph has the same behavior as a _model_ of a graph when applying an operation. For this, there are the `Model` type and `check_potential_isomorphism` function.

The `Model` type is an implementation of graph with the goal of being simple so it is easier to reason about its correctness. Moreover, it provides ways how to adjust the operations sequence according to specific needs using the `ModelParams` type and `check` method. The model itself can be tested on levels 1 and 2.

I believe it will be better to check consistency and model-conformance after every operation applied to reveal problems as soon as they occur.

The main reason for using stateful testing with sequence of operations is that it allows to assert validity of the graph also after removing operations, which are usually the hardest to implement correctly.

### Algorithms

For algorithms, we will mainly employ **property-based testing** with fast and customizable generation of the input graphs. For that, we will utilize [proptest](https://crates.io/crates/proptest) crate with custom `GraphStrategy`. The strategy is able to generate a graph into provided type if it implements standard graph manipulation traits. It is customizable via `StrategyParams` and thus is able to generate constrained graphs to reduce the number of cases when an algorithm would unnecessarily fail on a graph structure it does not support.

The graph algorithms outputs are relatively good for property-based testing. One can think of a few rules that apply to an output and often lemmas from the literature come handy. At the very least, we will usually have more than one algorithm for a problem, so that "oracle" test can be used to compare the results from different algorithms.