### PR TITLE
Add API for adding edges between vertices, inserted if not in graph

### DIFF
--- a/gryf/src/core/edges.rs
+++ b/gryf/src/core/edges.rs
@@ -111,7 +111,7 @@ impl fmt::Display for AddEdgeErrorKind {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 #[error("edge does not exist")]
 pub struct ReplaceEdgeError<E>(pub E);
 

--- a/gryf/src/core/vertices.rs
+++ b/gryf/src/core/vertices.rs
@@ -49,6 +49,19 @@ pub trait Vertices<V>: VerticesBase {
 
     fn vertex(&self, index: &Self::VertexIndex) -> Option<&V>;
     fn vertices(&self) -> Self::VerticesIter<'_>;
+
+    fn find_vertex(&self, vertex: &V) -> Option<Self::VertexIndex>
+    where
+        V: Eq,
+    {
+        self.vertices().find_map(|v| {
+            if v.data() == vertex {
+                Some(v.index().clone())
+            } else {
+                None
+            }
+        })
+    }
 }
 
 #[derive(Debug, Error, PartialEq)]
@@ -123,6 +136,26 @@ pub trait VerticesMut<V>: Vertices<V> {
 
         for v in vertices {
             self.remove_vertex(&v);
+        }
+    }
+
+    fn try_get_or_add_vertex(&mut self, vertex: V) -> Result<Self::VertexIndex, AddVertexError<V>>
+    where
+        V: Eq,
+    {
+        match self.find_vertex(&vertex) {
+            Some(v) => Ok(v),
+            None => self.try_add_vertex(vertex),
+        }
+    }
+
+    fn get_or_add_vertex(&mut self, vertex: V) -> Self::VertexIndex
+    where
+        V: Eq,
+    {
+        match self.try_get_or_add_vertex(vertex) {
+            Ok(index) => index,
+            Err(error) => panic!("{error}"),
         }
     }
 }

--- a/gryf/src/graph.rs
+++ b/gryf/src/graph.rs
@@ -3,3 +3,15 @@ mod path;
 
 pub use generic::Graph;
 pub use path::{Path, PathError};
+
+use thiserror::Error;
+
+use crate::core::{AddEdgeError, AddVertexError};
+
+#[derive(Debug, Error, PartialEq)]
+pub enum AddEdgeConnectingError<V, E> {
+    #[error("{0}")]
+    AddVertex(#[from] AddVertexError<V>),
+    #[error("{0}")]
+    AddEdge(#[from] AddEdgeError<E>),
+}


### PR DESCRIPTION
This adds API for adding edges, while also adding given vertices if they are not yet present in the graph. In petgraph, there is [GraphMap](https://docs.rs/petgraph/latest/petgraph/graphmap/struct.GraphMap.html) type for this use case. With a new storage which would use the same implementation as petgraph's `GraphMap` for storing vertices and edges and override `find_vertex` method, the performance characteristics for `add_edge_connecting` should be mostly the same as `GraphMap::add_edge`.

The definition of `find_vertex` on the `Vertices` trait requires only `Eq` trait. However, the implementation of `GraphMap` requires `Ord + Hash`. I believe that this is fine, because it is technically possible to put the constraints on the `impl` itself, i.e., `impl<V, ...> Vertices for Map where V: Ord + Hash`. 