### PR TITLE
Add algoritm for checking connectedness of a graph/vertices

### DIFF
--- a/gryf/src/algo.rs
+++ b/gryf/src/algo.rs
@@ -1,5 +1,7 @@
+pub mod connected;
 pub mod shortest_paths;
 pub mod toposort;
 
+pub use connected::{is_connected, is_path_between, Connected};
 pub use shortest_paths::ShortestPaths;
 pub use toposort::TopoSort;

--- a/gryf/src/algo/connected.rs
+++ b/gryf/src/algo/connected.rs
@@ -1,0 +1,382 @@
+use crate::core::{marker::EdgeType, EdgesBase, GraphBase, Neighbors, VerticesBase};
+
+mod builder;
+mod dfs;
+
+pub use builder::ConnectedBuilder;
+
+pub struct Connected<G>
+where
+    G: GraphBase,
+{
+    disconnected_any: Option<(G::VertexIndex, G::VertexIndex)>,
+    as_undirected: bool,
+}
+
+impl<G> Connected<G>
+where
+    G: GraphBase,
+{
+    pub fn is(&self) -> bool {
+        self.disconnected_any.is_none()
+    }
+
+    pub fn disconnected_any(&self) -> Option<(&G::VertexIndex, &G::VertexIndex)> {
+        self.disconnected_any.as_ref().map(|(ref u, ref v)| (u, v))
+    }
+
+    pub fn as_undirected(&self) -> bool {
+        self.as_undirected
+    }
+}
+
+pub fn is_connected<Ty: EdgeType, G>(graph: &G) -> bool
+where
+    G: Neighbors + VerticesBase + EdgesBase<Ty>,
+{
+    Connected::on(graph).run().is()
+}
+
+pub fn is_path_between<Ty: EdgeType, G>(
+    graph: &G,
+    src: &G::VertexIndex,
+    dst: &G::VertexIndex,
+) -> bool
+where
+    G: Neighbors + VerticesBase + EdgesBase<Ty>,
+{
+    Connected::on(graph).between(src, dst).run().is()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use proptest::prelude::*;
+
+    use crate::{
+        common::VisitSet,
+        core::{
+            index::VertexIndex,
+            marker::{Directed, Direction, Undirected},
+            EdgesMut, NeighborRef, VerticesMut,
+        },
+        infra::proptest::{graph_directed, graph_undirected},
+        storage::AdjList,
+    };
+
+    use super::*;
+
+    fn assert_valid<G>(
+        connected: Connected<G>,
+        graph: &G,
+        between: Option<(G::VertexIndex, G::VertexIndex)>,
+    ) where
+        G: Neighbors + VerticesBase,
+    {
+        match connected.disconnected_any() {
+            Some((u, v)) => {
+                // Check that the vertices are indeed disconnected. Also check
+                // if the given vertices are disconnected.
+                for (u, v) in std::iter::once((u.clone(), v.clone())).chain(between.clone()) {
+                    let mut visited = HashSet::with_capacity(graph.vertex_count());
+                    let mut stack = vec![u.clone()];
+
+                    while let Some(w) = stack.pop() {
+                        assert!(
+                            w != v,
+                            "algorithm reported connected vertices as disconnected ({:?}, {:?})",
+                            u,
+                            v
+                        );
+
+                        if visited.visit(w.clone()) {
+                            for n in graph.neighbors_directed(&w, Direction::Outgoing) {
+                                stack.push(n.index().into_owned());
+                            }
+                        }
+                    }
+                }
+            }
+            None => {
+                // Check that the graph is indeed connected. We use undirected
+                // algorithm which is simpler and therefore correct. This is
+                // fine because connected graph in directed sense is also
+                // connected in undirected sense. We are missing case in which
+                // the algorithm determined that a directed graph is connected,
+                // while it is not in directed sense, but is in undirected
+                // sense.
+                let mut visited = HashSet::with_capacity(graph.vertex_count());
+                let start = match between {
+                    Some((ref start, _)) => start.clone(),
+                    None => match graph.vertex_indices().next() {
+                        Some(start) => start,
+                        None => return,
+                    },
+                };
+                let mut stack = vec![start];
+
+                while let Some(u) = stack.pop() {
+                    if visited.visit(u.clone()) {
+                        for n in graph.neighbors(&u) {
+                            stack.push(n.index().into_owned());
+                        }
+                    }
+                }
+
+                if let Some((_, dst)) = between {
+                    assert!(
+                        visited.is_visited(&dst),
+                        "algorithm reported connected vertices while they are not"
+                    )
+                } else {
+                    assert_eq!(
+                        visited.visited_count(),
+                        graph.vertex_count(),
+                        "algorithm reported connected graph while it is not"
+                    )
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn connected_basic_undirected() {
+        let mut graph = AdjList::<_, _, Undirected, _>::default();
+
+        let v0 = graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        let v2 = graph.add_vertex(());
+
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v1, &v2, ());
+
+        let connected = Connected::on(&graph).run();
+        assert!(connected.is());
+    }
+
+    #[test]
+    fn connected_basic_directed() {
+        let mut graph = AdjList::<_, _, Directed, _>::default();
+
+        let v0 = graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        let v2 = graph.add_vertex(());
+
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v1, &v2, ());
+
+        let connected = Connected::on(&graph).run();
+        assert!(connected.is());
+    }
+
+    #[test]
+    fn connected_directed_reversed() {
+        let mut graph = AdjList::<_, _, Directed, _>::default();
+
+        let v0 = graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        let v2 = graph.add_vertex(());
+
+        graph.add_edge(&v1, &v0, ());
+        graph.add_edge(&v2, &v1, ());
+
+        let connected = Connected::on(&graph).run();
+        assert!(connected.is());
+    }
+
+    #[test]
+    fn disconnected_basic_undirected() {
+        let mut graph = AdjList::<_, _, Undirected, _>::default();
+
+        let v0 = graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        let v2 = graph.add_vertex(());
+
+        graph.add_edge(&v0, &v1, ());
+
+        let connected = Connected::on(&graph).run();
+        assert!(!connected.is());
+        assert_eq!(
+            connected
+                .disconnected_any()
+                .map(|(u, v)| [u, v].contains(&&v2)),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn disconnected_basic_directed() {
+        let mut graph = AdjList::<_, _, Directed, _>::default();
+
+        let v0 = graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        let v2 = graph.add_vertex(());
+
+        graph.add_edge(&v0, &v1, ());
+
+        let connected = Connected::on(&graph).run();
+        assert!(!connected.is());
+        assert_eq!(
+            connected
+                .disconnected_any()
+                .map(|(u, v)| [u, v].contains(&&v2)),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn disconnected_weakly_basic_directed() {
+        let mut graph = AdjList::<_, _, Directed, _>::default();
+
+        let v0 = graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        let v2 = graph.add_vertex(());
+
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v2, &v1, ());
+
+        let connected = Connected::on(&graph).run();
+        assert!(!connected.is());
+        assert_eq!(connected.disconnected_any(), Some((&v0, &v2)));
+    }
+
+    #[test]
+    fn disconnected_directed_circles() {
+        let mut graph = AdjList::<_, _, Directed, _>::default();
+
+        let v0 = graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        let v2 = graph.add_vertex(());
+
+        let v3 = graph.add_vertex(());
+        let v4 = graph.add_vertex(());
+        let v5 = graph.add_vertex(());
+
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v1, &v2, ());
+        graph.add_edge(&v2, &v0, ());
+
+        graph.add_edge(&v3, &v4, ());
+        graph.add_edge(&v4, &v5, ());
+        graph.add_edge(&v5, &v3, ());
+
+        let connected = Connected::on(&graph).run();
+        assert!(!connected.is());
+    }
+
+    #[test]
+    fn connected_directed_as_undirected() {
+        let mut graph = AdjList::<_, _, Directed, _>::default();
+
+        let v0 = graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        let v2 = graph.add_vertex(());
+
+        graph.add_edge(&v0, &v1, ());
+        graph.add_edge(&v2, &v1, ());
+
+        let connected = Connected::on(&graph).as_undirected().run();
+        assert!(connected.is());
+        assert!(connected.as_undirected());
+    }
+
+    #[test]
+    fn connected_between_disconnected_otherwise_undirected() {
+        let mut graph = AdjList::<_, _, Undirected, _>::default();
+
+        let v0 = graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        graph.add_vertex(());
+
+        graph.add_edge(&v0, &v1, ());
+
+        let connected = Connected::on(&graph).between(&v0, &v1).run();
+        assert!(connected.is());
+    }
+
+    #[test]
+    fn disconnected_between_undirected() {
+        let mut graph = AdjList::<_, _, Undirected, _>::default();
+
+        let v0 = graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        let v2 = graph.add_vertex(());
+
+        graph.add_edge(&v0, &v1, ());
+
+        let connected = Connected::on(&graph).between(&v0, &v2).run();
+        assert!(!connected.is());
+        assert_eq!(connected.disconnected_any(), Some((&v0, &v2)));
+    }
+
+    #[test]
+    fn connected_empty() {
+        let graph = AdjList::<(), (), Undirected, _>::default();
+
+        let connected = Connected::on(&graph).run();
+        assert!(connected.is());
+    }
+
+    #[test]
+    fn connected_single() {
+        let mut graph = AdjList::<_, (), Undirected, _>::default();
+
+        graph.add_vertex(());
+
+        let connected = Connected::on(&graph).run();
+        assert!(connected.is());
+    }
+
+    #[test]
+    fn connected_with_itself() {
+        let mut graph = AdjList::<_, (), Undirected, _>::default();
+
+        graph.add_vertex(());
+        let v1 = graph.add_vertex(());
+        graph.add_vertex(());
+
+        let connected = Connected::on(&graph).between(&v1, &v1).run();
+        assert!(connected.is());
+    }
+
+    proptest! {
+        #[test]
+        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
+        fn connected_undirected_any(graph in graph_undirected(any::<()>(), any::<()>())) {
+            let connected = Connected::on(&graph).run();
+            assert_valid(connected, &graph, None);
+        }
+
+        #[test]
+        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
+        fn connected_directed_any(graph in graph_directed(any::<()>(), any::<()>())) {
+            let connected = Connected::on(&graph).run();
+            assert_valid(connected, &graph, None);
+        }
+
+        #[test]
+        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
+        fn connected_between_undirected_any(graph in graph_undirected(any::<()>(), any::<()>()), src: u64, dst: u64) {
+            let n = graph.vertex_count() as u64;
+            prop_assume!(n > 0);
+
+            let src = VertexIndex(src % n);
+            let dst = VertexIndex(dst % n);
+            let connected = Connected::on(&graph).between(&src, &dst).run();
+            assert_valid(connected, &graph, Some((src, dst)));
+        }
+
+        #[test]
+        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
+        fn connected_between_directed_any(graph in graph_directed(any::<()>(), any::<()>()), src: u64, dst: u64) {
+            let n = graph.vertex_count() as u64;
+            prop_assume!(n > 0);
+
+            let src = VertexIndex(src % n);
+            let dst = VertexIndex(dst % n);
+            let connected = Connected::on(&graph).between(&src, &dst).run();
+            assert_valid(connected, &graph, Some((src, dst)));
+        }
+    }
+}

--- a/gryf/src/algo/connected/builder.rs
+++ b/gryf/src/algo/connected/builder.rs
@@ -1,0 +1,56 @@
+use crate::core::{marker::EdgeType, EdgesBase, GraphBase, Neighbors, VerticesBase};
+
+use super::{dfs::dfs, Connected};
+
+pub struct ConnectedBuilder<'a, G>
+where
+    G: GraphBase,
+{
+    graph: &'a G,
+    between: Option<(&'a G::VertexIndex, &'a G::VertexIndex)>,
+    as_undirected: bool,
+}
+
+impl<G> Connected<G>
+where
+    G: GraphBase,
+{
+    pub fn on(graph: &G) -> ConnectedBuilder<'_, G> {
+        ConnectedBuilder {
+            graph,
+            between: None,
+            as_undirected: false,
+        }
+    }
+}
+
+impl<'a, G> ConnectedBuilder<'a, G>
+where
+    G: GraphBase,
+{
+    pub fn between(self, src: &'a G::VertexIndex, dst: &'a G::VertexIndex) -> Self {
+        Self {
+            between: Some((src, dst)),
+            ..self
+        }
+    }
+
+    pub fn as_undirected(self) -> Self {
+        Self {
+            as_undirected: true,
+            ..self
+        }
+    }
+}
+
+impl<'a, G> ConnectedBuilder<'a, G>
+where
+    G: GraphBase,
+{
+    pub fn run<Ty: EdgeType>(self) -> Connected<G>
+    where
+        G: Neighbors + VerticesBase + EdgesBase<Ty>,
+    {
+        dfs(self.graph, self.between, self.as_undirected)
+    }
+}

--- a/gryf/src/algo/connected/dfs.rs
+++ b/gryf/src/algo/connected/dfs.rs
@@ -1,0 +1,148 @@
+use rustc_hash::FxHashSet;
+
+use crate::{
+    common::VisitSet,
+    core::{
+        marker::{Direction, EdgeType},
+        EdgesBase, NeighborRef, Neighbors, VerticesBase,
+    },
+};
+
+use super::Connected;
+
+pub fn dfs<Ty: EdgeType, G>(
+    graph: &G,
+    between: Option<(&G::VertexIndex, &G::VertexIndex)>,
+    as_undirected: bool,
+) -> Connected<G>
+where
+    G: Neighbors + VerticesBase + EdgesBase<Ty>,
+{
+    let (start, goal) = match between {
+        Some((start, goal)) => {
+            if start == goal {
+                // A vertex is trivially connected with itself.
+                return Connected {
+                    disconnected_any: None,
+                    as_undirected,
+                };
+            } else {
+                (start.clone(), Some(goal))
+            }
+        }
+        None if Ty::is_directed() && !as_undirected => match graph
+            .vertex_indices()
+            // For directed graph, we can't start in any vertex, because then we
+            // might miss the predecessors of such vertex and incorrectly mark
+            // the graph as disconnected. Only if there is no vertex with in
+            // degree 0, it is safe to start in any vertex.
+            .find(|v| graph.degree_directed(v, Direction::Incoming) == 0)
+            .or_else(|| graph.vertex_indices().next())
+        {
+            Some(v) => (v, None),
+            None => {
+                // Empty graph is trivially "connected".
+                return Connected {
+                    disconnected_any: None,
+                    as_undirected,
+                };
+            }
+        },
+        None => match graph.vertex_indices().next() {
+            Some(v) => (v, None),
+            None => {
+                // Empty graph is trivially "connected".
+                return Connected {
+                    disconnected_any: None,
+                    as_undirected,
+                };
+            }
+        },
+    };
+
+    let mut visited = FxHashSet::default();
+    visited.reserve(graph.vertex_count());
+    let mut stack = vec![start.clone()];
+
+    match (goal, as_undirected) {
+        (None, false) => {
+            while let Some(v) = stack.pop() {
+                if visited.visit(v.clone()) {
+                    for n in graph.neighbors_directed(&v, Direction::Outgoing) {
+                        stack.push(n.index().into_owned());
+                    }
+                }
+            }
+        }
+        (None, true) => {
+            while let Some(v) = stack.pop() {
+                if visited.visit(v.clone()) {
+                    for n in graph.neighbors(&v) {
+                        stack.push(n.index().into_owned());
+                    }
+                }
+            }
+        }
+        (Some(goal), false) => {
+            while let Some(v) = stack.pop() {
+                if &v == goal {
+                    return Connected {
+                        disconnected_any: None,
+                        as_undirected,
+                    };
+                }
+
+                if visited.visit(v.clone()) {
+                    for n in graph.neighbors_directed(&v, Direction::Outgoing) {
+                        stack.push(n.index().into_owned());
+                    }
+                }
+            }
+        }
+        (Some(goal), true) => {
+            while let Some(v) = stack.pop() {
+                if &v == goal {
+                    return Connected {
+                        disconnected_any: None,
+                        as_undirected,
+                    };
+                }
+
+                if visited.visit(v.clone()) {
+                    for n in graph.neighbors(&v) {
+                        stack.push(n.index().into_owned());
+                    }
+                }
+            }
+        }
+    }
+
+    if visited.visited_count() == graph.vertex_count() {
+        Connected {
+            disconnected_any: None,
+            as_undirected,
+        }
+    } else {
+        if let Some(goal) = goal {
+            // If the goal was not visited, we can use it specifically for
+            // disconnected pair without looking for an arbitrary unvisited
+            // vertex.
+            if !visited.is_visited(goal) {
+                return Connected {
+                    disconnected_any: Some((start, goal.clone())),
+                    as_undirected,
+                };
+            }
+        }
+
+        let v = graph
+            .vertex_indices()
+            .find(|v| !visited.is_visited(v))
+            .expect("unvisited vertex");
+
+        Connected {
+            disconnected_any: Some((start, v)),
+            as_undirected,
+        }
+    }
+}


### PR DESCRIPTION
This mainly serves as a precedent for algorithms with our standard structure (`on(graph)` constructor, builder pattern, result struct), which may also have "aliases" in form of a standalone function with simpler input and simpler output.