### PR TITLE
Implement indexing for graph encapsulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fn main() {
     let distance = shortest_paths[prague];
     let path = shortest_paths
         .reconstruct(prague)
-        .map(|v| *graph.vertex(v).unwrap())
+        .map(|v| graph[v])
         .collect::<Vec<_>>()
         .join(" - ");
 

--- a/gryf/examples/shortest_path.rs
+++ b/gryf/examples/shortest_path.rs
@@ -28,7 +28,7 @@ fn main() {
     let distance = shortest_paths[prague];
     let path = shortest_paths
         .reconstruct(prague)
-        .map(|v| *graph.vertex(v).unwrap())
+        .map(|v| graph[v])
         .collect::<Vec<_>>()
         .join(" - ");
 

--- a/gryf/src/graph/generic.rs
+++ b/gryf/src/graph/generic.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Borrow,
     marker::PhantomData,
-    ops::{Deref, DerefMut},
+    ops::{Deref, DerefMut, Index, IndexMut},
 };
 
 use crate::{
@@ -505,5 +505,27 @@ where
 {
     fn with_capacity(vertex_count: usize, edge_count: usize) -> Self {
         Self::new_in(G::with_capacity(vertex_count, edge_count))
+    }
+}
+
+impl<V, E, Ty: EdgeType, G, VI> Index<VI> for Graph<V, E, Ty, G>
+where
+    G: Vertices<V>,
+    VI: Borrow<G::VertexIndex>,
+{
+    type Output = V;
+
+    fn index(&self, index: VI) -> &Self::Output {
+        self.vertex(index).expect("vertex does not exist")
+    }
+}
+
+impl<V, E, Ty: EdgeType, G, VI> IndexMut<VI> for Graph<V, E, Ty, G>
+where
+    G: VerticesMut<V>,
+    VI: Borrow<G::VertexIndex>,
+{
+    fn index_mut(&mut self, index: VI) -> &mut Self::Output {
+        self.vertex_mut(index).expect("vertex does not exist")
     }
 }

--- a/gryf/src/graph/path.rs
+++ b/gryf/src/graph/path.rs
@@ -1,4 +1,9 @@
-use std::{borrow::Borrow, hash::BuildHasherDefault, marker::PhantomData, ops::Deref};
+use std::{
+    borrow::Borrow,
+    hash::BuildHasherDefault,
+    marker::PhantomData,
+    ops::{Deref, Index, IndexMut},
+};
 
 use rustc_hash::FxHashSet;
 use thiserror::Error;
@@ -649,6 +654,28 @@ where
 
     fn deref(&self) -> &Self::Target {
         &self.storage
+    }
+}
+
+impl<V, E, Ty: EdgeType, G, VI> Index<VI> for Path<V, E, Ty, G>
+where
+    G: Vertices<V>,
+    VI: Borrow<G::VertexIndex>,
+{
+    type Output = V;
+
+    fn index(&self, index: VI) -> &Self::Output {
+        self.vertex(index).expect("vertex does not exist")
+    }
+}
+
+impl<V, E, Ty: EdgeType, G, VI> IndexMut<VI> for Path<V, E, Ty, G>
+where
+    G: VerticesMut<V>,
+    VI: Borrow<G::VertexIndex>,
+{
+    fn index_mut(&mut self, index: VI) -> &mut Self::Output {
+        self.vertex_mut(index).expect("vertex does not exist")
     }
 }
 


### PR DESCRIPTION
Partially implements #15. Supporting edge indexing will not be straightforward because of the generic index types.