### PR TITLE
Use ignore attribute instead of cfg flag for proptest tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,3 +53,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
       - run: cargo test proptest_ -- --ignored
+        if: matrix.rust == 'stable'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,6 @@ jobs:
       fail-fast: false
       matrix:
         rust: [stable, beta, nightly]
-    env:
-      # Property-based tests are ignored if not compiled with this --cfg.
-      RUSTFLAGS: --cfg proptest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -55,3 +52,4 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
+      - run: cargo test proptest_ -- --ignored

--- a/gryf/Cargo.toml
+++ b/gryf/Cargo.toml
@@ -34,6 +34,3 @@ default = ["arbitrary", "proptest"]
 arbitrary = ["dep:arbitrary"]
 proptest = ["dep:proptest"]
 derive = []
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(proptest)'] }

--- a/gryf/src/algo/connected.rs
+++ b/gryf/src/algo/connected.rs
@@ -338,22 +338,22 @@ mod tests {
 
     proptest! {
         #[test]
-        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
-        fn connected_undirected_any(graph in graph_undirected(any::<()>(), any::<()>())) {
+        #[ignore = "run property-based tests with `cargo test proptest_ -- --ignored`"]
+        fn proptest_connected_undirected_any(graph in graph_undirected(any::<()>(), any::<()>())) {
             let connected = Connected::on(&graph).run();
             assert_valid(connected, &graph, None);
         }
 
         #[test]
-        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
-        fn connected_directed_any(graph in graph_directed(any::<()>(), any::<()>())) {
+        #[ignore = "run property-based tests with `cargo test proptest_ -- --ignored`"]
+        fn proptest_connected_directed_any(graph in graph_directed(any::<()>(), any::<()>())) {
             let connected = Connected::on(&graph).run();
             assert_valid(connected, &graph, None);
         }
 
         #[test]
-        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
-        fn connected_between_undirected_any(graph in graph_undirected(any::<()>(), any::<()>()), src: u64, dst: u64) {
+        #[ignore = "run property-based tests with `cargo test proptest_ -- --ignored`"]
+        fn proptest_connected_between_undirected_any(graph in graph_undirected(any::<()>(), any::<()>()), src: u64, dst: u64) {
             let n = graph.vertex_count() as u64;
             prop_assume!(n > 0);
 
@@ -364,8 +364,8 @@ mod tests {
         }
 
         #[test]
-        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
-        fn connected_between_directed_any(graph in graph_directed(any::<()>(), any::<()>()), src: u64, dst: u64) {
+        #[ignore = "run property-based tests with `cargo test proptest_ -- --ignored`"]
+        fn proptest_connected_between_directed_any(graph in graph_directed(any::<()>(), any::<()>()), src: u64, dst: u64) {
             let n = graph.vertex_count() as u64;
             prop_assume!(n > 0);
 

--- a/gryf/src/algo/shortest_paths.rs
+++ b/gryf/src/algo/shortest_paths.rs
@@ -369,8 +369,8 @@ mod tests {
 
     proptest! {
         #[test]
-        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
-        fn dijkstra_any(graph in graph_undirected(any::<()>(), any::<u16>().prop_map(|e| e as u32)), start: u64) {
+        #[ignore = "run property-based tests with `cargo test proptest_ -- --ignored`"]
+        fn proptest_dijkstra_any(graph in graph_undirected(any::<()>(), any::<u16>().prop_map(|e| e as u32)), start: u64) {
             let n = graph.vertex_count() as u64;
             prop_assume!(n > 0);
 
@@ -380,8 +380,8 @@ mod tests {
         }
 
         #[test]
-        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
-        fn bellman_ford_any(graph in graph_directed(any::<()>(), any::<i16>().prop_map(|e| e as i32)).max_size(128), start: u64) {
+        #[ignore = "run property-based tests with `cargo test proptest_ -- --ignored`"]
+        fn proptest_bellman_ford_any(graph in graph_directed(any::<()>(), any::<i16>().prop_map(|e| e as i32)).max_size(128), start: u64) {
             let n = graph.vertex_count() as u64;
             prop_assume!(n > 0);
 

--- a/gryf/src/algo/toposort.rs
+++ b/gryf/src/algo/toposort.rs
@@ -353,29 +353,29 @@ mod tests {
 
     proptest! {
         #[test]
-        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
-        fn toposort_dfs_acyclic(graph in graph_directed(any::<()>(), any::<()>()).acyclic()) {
+        #[ignore = "run property-based tests with `cargo test proptest_ -- --ignored`"]
+        fn proptest_toposort_dfs_acyclic(graph in graph_directed(any::<()>(), any::<()>()).acyclic()) {
             let toposort = TopoSort::on(&graph).with(Algo::Dfs).run();
             assert_valid(toposort, &graph);
         }
 
         #[test]
-        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
-        fn toposort_dfs_any(graph in graph_directed(any::<()>(), any::<()>())) {
+        #[ignore = "run property-based tests with `cargo test proptest_ -- --ignored`"]
+        fn proptest_toposort_dfs_any(graph in graph_directed(any::<()>(), any::<()>())) {
             let toposort = TopoSort::on(&graph).with(Algo::Dfs).run();
             assert_valid(toposort, &graph);
         }
 
         #[test]
-        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
-        fn toposort_kahn_acyclic(graph in graph_directed(any::<()>(), any::<()>()).acyclic()) {
+        #[ignore = "run property-based tests with `cargo test proptest_ -- --ignored`"]
+        fn proptest_toposort_kahn_acyclic(graph in graph_directed(any::<()>(), any::<()>()).acyclic()) {
             let toposort = TopoSort::on(&graph).with(Algo::Kahn).run();
             assert_valid(toposort, &graph);
         }
 
         #[test]
-        #[cfg_attr(not(proptest), ignore = "compile with --cfg proptest")]
-        fn toposort_kahn_any(graph in graph_directed(any::<()>(), any::<()>())) {
+        #[ignore = "run property-based tests with `cargo test proptest_ -- --ignored`"]
+        fn proptest_toposort_kahn_any(graph in graph_directed(any::<()>(), any::<()>())) {
             let toposort = TopoSort::on(&graph).with(Algo::Kahn).run();
             assert_valid(toposort, &graph);
         }


### PR DESCRIPTION
This is a better solution because it doesn't require recompilation or ignoring lint warnings.