### PR TITLE
Expose existing adapters in the docs

### DIFF
--- a/gryf/src/adapt.rs
+++ b/gryf/src/adapt.rs
@@ -1,20 +1,15 @@
 //! Various graph adapters.
 
-#[doc(hidden)]
 pub mod complement;
-#[doc(hidden)]
+pub mod subgraph;
 pub mod transpose;
-#[doc(hidden)]
 pub mod undirect;
 
-pub mod subgraph;
-
-#[doc(hidden)]
+#[doc(inline)]
 pub use complement::Complement;
-#[doc(hidden)]
-pub use transpose::Transpose;
-#[doc(hidden)]
-pub use undirect::Undirect;
-
 #[doc(inline)]
 pub use subgraph::Subgraph;
+#[doc(inline)]
+pub use transpose::Transpose;
+#[doc(inline)]
+pub use undirect::Undirect;

--- a/gryf/src/adapt/transpose.rs
+++ b/gryf/src/adapt/transpose.rs
@@ -1,3 +1,8 @@
+//! The [transpose] of a directed graph, that is, the same graph but with
+//! orientation of edges reversed.
+//!
+//! [transpose]: https://en.wikipedia.org/wiki/Transpose_graph
+
 use crate::core::{
     EdgeSet, GraphBase, GraphFull, GraphRef, Neighbors,
     base::{EdgeReference, NeighborReference},
@@ -9,6 +14,10 @@ use crate::core::{
 
 use gryf_derive::{GraphBase, GraphMut, Guarantee, VertexSet};
 
+/// The [transpose] of a directed graph, that is, the same graph but with
+/// orientation of edges reversed.
+///
+/// [transpose]: https://en.wikipedia.org/wiki/Transpose_graph
 #[derive(Debug, GraphBase, VertexSet, GraphMut, Guarantee)]
 #[gryf_crate]
 pub struct Transpose<G> {
@@ -20,14 +29,17 @@ impl<G> Transpose<G>
 where
     G: GraphBase<EdgeType = Directed>,
 {
+    /// Creates a transpose of the given graph.
     pub fn new(graph: G) -> Self {
         Self { graph }
     }
 
+    /// Consumes the adapter and returns the wrapped graph.
     pub fn into_inner(self) -> G {
         self.graph
     }
 
+    #[doc(hidden)]
     pub fn apply<V, E, S: Stability>(self) -> G
     where
         G: GraphFull<V, E> + StableId<G::EdgeId, S>,

--- a/gryf/src/adapt/undirect.rs
+++ b/gryf/src/adapt/undirect.rs
@@ -1,7 +1,10 @@
+//! Adapter that removes directionality of edges of a directed graph.
+
 use crate::core::{Neighbors, marker::Direction};
 
 use gryf_derive::{EdgeSet, GraphBase, Guarantee, VertexSet};
 
+/// Adapter that removes directionality of edges of a directed graph.
 #[derive(Debug, GraphBase, VertexSet, EdgeSet, Guarantee)]
 #[gryf_crate]
 pub struct Undirect<G> {
@@ -10,10 +13,13 @@ pub struct Undirect<G> {
 }
 
 impl<G> Undirect<G> {
+    /// Creates a new graph which removes directionality of edges of the given
+    /// graph.
     pub fn new(graph: G) -> Self {
         Self { graph }
     }
 
+    /// Consumes the adapter and returns the wrapped graph.
     pub fn into_inner(self) -> G {
         self.graph
     }


### PR DESCRIPTION
Previously, existing adapters were hidden in the docs, although some of them were used internally. I am not certain about what API adapters should provide, but that should probably not block their exposure.